### PR TITLE
feat: improve mobile UI responsiveness and usability

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -271,6 +271,120 @@
     color: white;
 }
 
+/* Mobile-Optimized Styles for Homepage */
+@media (max-width: 640px) {
+    /* Compact welcome header */
+    .mobile-compact-header h1 {
+        font-size: 1.75rem !important;
+        margin-bottom: 0.5rem !important;
+    }
+    
+    .mobile-compact-header p {
+        font-size: 0.875rem !important;
+        line-height: 1.25rem !important;
+    }
+    
+    /* Quick action cards - full width and compact */
+    .mobile-action-card {
+        padding: 1rem !important;
+    }
+    
+    .mobile-action-card .mobile-icon-box {
+        width: 2.5rem !important;
+        height: 2.5rem !important;
+    }
+    
+    .mobile-action-card h3 {
+        font-size: 1rem !important;
+    }
+    
+    .mobile-action-card p {
+        font-size: 0.75rem !important;
+    }
+    
+    /* Album cards - more compact */
+    .mobile-album-card {
+        padding: 0.75rem !important;
+    }
+    
+    .mobile-album-card .album-art {
+        width: 3rem !important;
+        height: 3rem !important;
+        flex-shrink: 0;
+    }
+    
+    .mobile-album-card .album-art svg {
+        width: 1.5rem !important;
+        height: 1.5rem !important;
+    }
+    
+    /* Rating scale - 2x2 grid */
+    .mobile-rating-grid {
+        grid-template-columns: repeat(2, 1fr) !important;
+        gap: 0.5rem !important;
+    }
+    
+    .mobile-rating-item {
+        padding: 0.5rem !important;
+    }
+    
+    .mobile-rating-item .rating-icon {
+        width: 1.75rem !important;
+        height: 1.75rem !important;
+        font-size: 0.625rem !important;
+    }
+    
+    .mobile-rating-item .rating-label {
+        font-size: 0.875rem !important;
+    }
+    
+    .mobile-rating-item .rating-desc {
+        font-size: 0.625rem !important;
+    }
+    
+    /* Hide getting started guide steps on mobile by default */
+    .mobile-collapsible {
+        max-height: 0;
+        overflow: hidden;
+        transition: max-height 0.3s ease-out;
+    }
+    
+    .mobile-collapsible.expanded {
+        max-height: 500px;
+    }
+    
+    /* Reduce section spacing */
+    .mobile-section-spacing {
+        margin-bottom: 2rem !important;
+    }
+    
+    /* Hide loading skeletons beyond 3 on mobile */
+    .mobile-hide-skeleton:nth-child(n+4) {
+        display: none !important;
+    }
+    
+    /* Compact section headers */
+    .mobile-section-header h2 {
+        font-size: 1.25rem !important;
+    }
+    
+    .mobile-section-header a {
+        font-size: 0.75rem !important;
+    }
+}
+
+/* Tablet adjustments */
+@media (min-width: 641px) and (max-width: 768px) {
+    .tablet-album-card {
+        padding: 1rem !important;
+    }
+    
+    .tablet-album-art {
+        width: 4rem !important;
+        height: 4rem !important;
+    }
+}
+
 /* Print Styles */
 @media print {
     .no-print {

--- a/templates/album/rating.html
+++ b/templates/album/rating.html
@@ -7,26 +7,26 @@
 {% block content %}
 <div class="max-w-6xl mx-auto">
     <!-- Album Header -->
-    <div class="bg-white rounded-lg shadow-sm border border-gray-200 mb-6">
-        <div class="p-8">
-            <div class="flex flex-col lg:flex-row lg:items-center space-y-6 lg:space-y-0 lg:space-x-8">
+    <div class="bg-white rounded-lg shadow-sm border border-gray-200 mb-4 md:mb-6">
+        <div class="p-4 sm:p-6 md:p-8">
+            <div class="flex flex-col lg:flex-row lg:items-center space-y-4 sm:space-y-6 lg:space-y-0 lg:space-x-8">
                 <!-- Album Artwork -->
-                <div class="flex-shrink-0">
-                    <div class="w-48 h-48 rounded-lg overflow-hidden">
+                <div class="flex-shrink-0 mx-auto lg:mx-0">
+                    <div class="w-24 h-24 sm:w-32 sm:h-32 md:w-40 md:h-40 lg:w-48 lg:h-48 rounded-lg overflow-hidden">
                         <img src="{{ get_artwork_url(album, 'large') }}" 
                              alt="{{ album.title }} cover" 
                              class="w-full h-full object-cover"
-                             onerror="this.onerror=null; this.parentElement.innerHTML='<div class=\'w-48 h-48 bg-gradient-to-br from-gray-200 to-gray-300 rounded-lg flex items-center justify-center\'><svg class=\'w-24 h-24 text-gray-400\' fill=\'none\' stroke=\'currentColor\' viewBox=\'0 0 24 24\'><path stroke-linecap=\'round\' stroke-linejoin=\'round\' stroke-width=\'2\' d=\'M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zm12-3c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zM9 10l12-3\'></path></svg></div>';">
+                             onerror="this.onerror=null; this.parentElement.innerHTML='<div class=\'w-full h-full bg-gradient-to-br from-gray-200 to-gray-300 rounded-lg flex items-center justify-center\'><svg class=\'w-12 sm:w-16 md:w-20 lg:w-24 h-12 sm:h-16 md:h-20 lg:h-24 text-gray-400\' fill=\'none\' stroke=\'currentColor\' viewBox=\'0 0 24 24\'><path stroke-linecap=\'round\' stroke-linejoin=\'round\' stroke-width=\'2\' d=\'M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zm12-3c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zM9 10l12-3\'></path></svg></div>';">
                     </div>
                 </div>
                 
                 <!-- Album Info -->
-                <div class="flex-1">
-                    <div class="flex items-start justify-between mb-2">
-                        <h1 class="text-3xl font-bold text-gray-900 group relative inline-block{% if album.genre %} cursor-help{% endif %}">
+                <div class="flex-1 text-center lg:text-left">
+                    <div class="flex flex-col sm:flex-row items-start justify-between mb-2">
+                        <h1 class="text-xl sm:text-2xl md:text-3xl font-bold text-gray-900 group relative inline-block{% if album.genre %} cursor-help{% endif %}">
                             {{ album.title }}
                             {% if album.year %}
-                            <span class="text-2xl font-normal text-gray-500">(<a href="/years/{{ album.year }}/albums" class="hover:text-blue-600 hover:underline transition-colors">{{ album.year }}</a>)</span>
+                            <span class="text-lg sm:text-xl md:text-2xl font-normal text-gray-500">(<a href="/years/{{ album.year }}/albums" class="hover:text-blue-600 hover:underline transition-colors">{{ album.year }}</a>)</span>
                             {% endif %}
                             {% if album.genre %}
                             <span class="absolute -bottom-8 left-0 text-xs bg-gray-800 text-white px-2 py-1 rounded opacity-0 group-hover:opacity-100 transition-opacity whitespace-nowrap pointer-events-none z-10">
@@ -35,7 +35,7 @@
                             {% endif %}
                         </h1>
                         <!-- Action Buttons (No Edit Rating since it's in progress) -->
-                        <div class="flex items-center space-x-2 ml-4">
+                        <div class="flex items-center space-x-2 mt-2 sm:mt-0 sm:ml-4">
                             <button onclick="openRetagModal()" 
                                     title="Change Release Version"
                                     class="p-2 text-gray-400 hover:text-purple-600 hover:bg-purple-50 rounded-lg transition-all duration-200 group relative">
@@ -55,13 +55,13 @@
                             </a>
                         </div>
                     </div>
-                    <p class="text-xl text-gray-600 mb-6">by <a href="/artists/{{ album.artist.id }}/albums" class="hover:text-blue-600 hover:underline transition-colors">{{ album.artist.name }}</a></p>
+                    <p class="text-base sm:text-lg md:text-xl text-gray-600 mb-4 md:mb-6">by <a href="/artists/{{ album.artist.id }}/albums" class="hover:text-blue-600 hover:underline transition-colors">{{ album.artist.name }}</a></p>
                     
                     <!-- Rating Status -->
-                    <div class="bg-amber-50 border border-amber-200 rounded-lg p-4">
-                        <div class="text-center">
-                            <div class="text-lg font-semibold text-amber-800 mb-1">Rating in Progress</div>
-                            <div class="text-sm text-amber-600">Rate each track below to complete</div>
+                    <div class="bg-amber-50 border border-amber-200 rounded-lg p-3 md:p-4">
+                        <div class="text-center lg:text-left">
+                            <div class="text-base md:text-lg font-semibold text-amber-800 mb-0.5 md:mb-1">Rating in Progress</div>
+                            <div class="text-xs sm:text-sm text-amber-600">Rate each track below to complete</div>
                         </div>
                     </div>
                 </div>
@@ -74,14 +74,14 @@
     {% include 'components/progress_bar.html' %}
     
     <!-- Rating Instructions -->
-    <div class="bg-blue-50 border border-blue-200 rounded-lg p-4 mb-6">
+    <div class="bg-blue-50 border border-blue-200 rounded-lg p-3 md:p-4 mb-4 md:mb-6">
         <div class="flex items-start">
             <svg class="w-5 h-5 text-blue-400 mt-0.5 mr-3 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
             </svg>
             <div>
                 <h3 class="text-sm font-semibold text-blue-800 mb-1">How to Rate Tracks</h3>
-                <div class="text-sm text-blue-700 space-y-1">
+                <div class="text-xs sm:text-sm text-blue-700 space-y-0.5 sm:space-y-1">
                     <p><span class="font-medium text-red-600">Skip (0.0)</span> - Worst songs you'd never want to hear</p>
                     <p><span class="font-medium text-amber-600">Filler (0.33)</span> - Tolerable but not enjoyable, won't skip</p>
                     <p><span class="font-medium text-green-600">Good (0.67)</span> - Like the track, playlist-worthy</p>
@@ -94,30 +94,30 @@
     
     <!-- Track List -->
     <div class="bg-white rounded-lg shadow-sm border border-gray-200">
-        <div class="p-6">
-            <div class="flex items-baseline justify-between mb-6">
-                <h2 class="text-xl font-semibold text-gray-900">Rate Each Track</h2>
+        <div class="p-4 md:p-6">
+            <div class="flex items-baseline justify-between mb-4 md:mb-6">
+                <h2 class="text-lg md:text-xl font-semibold text-gray-900">Rate Each Track</h2>
                 {% if album.total_duration_ms %}
                 <span class="text-xs text-gray-500">Total Duration: {{ (album.total_duration_ms / 60000) | round(0) | int }} min</span>
                 {% endif %}
             </div>
             
-            <div class="space-y-4">
+            <div class="space-y-3 md:space-y-4">
                 {% for track in tracks %}
-                <div class="track-row{% if track.rating is not none %} rated{% endif %} p-4 rounded-lg border border-gray-100" 
+                <div class="track-row{% if track.rating is not none %} rated{% endif %} p-3 md:p-4 rounded-lg border border-gray-100" 
                      id="track-{{ track.id }}-row">
                     
                     <!-- Track Info -->
-                    <div class="flex flex-col lg:flex-row lg:items-center justify-between space-y-3 lg:space-y-0 lg:space-x-4">
+                    <div class="flex flex-col sm:flex-row sm:items-center justify-between space-y-3 sm:space-y-0 sm:space-x-4">
                         <div class="flex-1 min-w-0">
-                            <div class="flex items-center space-x-3">
-                                <span class="flex-shrink-0 w-8 h-8 bg-gray-100 rounded-full flex items-center justify-center text-sm font-medium text-gray-600">
+                            <div class="flex items-center space-x-2 sm:space-x-3">
+                                <span class="flex-shrink-0 w-7 h-7 sm:w-8 sm:h-8 bg-gray-100 rounded-full flex items-center justify-center text-xs sm:text-sm font-medium text-gray-600">
                                     {{ track.track_number }}
                                 </span>
                                 <div class="min-w-0 flex-1">
-                                    <h3 class="text-base font-medium text-gray-900 truncate">{{ track.title }}</h3>
+                                    <h3 class="text-sm sm:text-base font-medium text-gray-900 truncate">{{ track.title }}</h3>
                                     {% if track.duration_ms %}
-                                    <p class="text-sm text-gray-500">{{ track.duration_ms | format_duration }}</p>
+                                    <p class="text-xs sm:text-sm text-gray-500">{{ track.duration_ms | format_duration }}</p>
                                     {% endif %}
                                 </div>
                             </div>

--- a/templates/albums.html
+++ b/templates/albums.html
@@ -22,7 +22,7 @@
                 Update Cover Art
             </button>
             <a href="/search" 
-               class="inline-flex items-center px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium rounded-md transition-colors">
+               class="inline-flex items-center px-3 py-2 sm:px-4 bg-blue-600 hover:bg-blue-700 text-white text-xs sm:text-sm font-medium rounded-md transition-colors">
                 <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6"></path>
                 </svg>

--- a/templates/base.html
+++ b/templates/base.html
@@ -8,6 +8,9 @@
     <!-- Favicon -->
     <link rel="icon" type="image/x-icon" href="/static/img/favicon.ico">
     
+    <!-- Apple Touch Icon -->
+    <link rel="apple-touch-icon" href="/static/img/logo-512.png">
+    
     <!-- Tailwind CSS -->
     <script src="https://cdn.tailwindcss.com"></script>
     <script>
@@ -101,7 +104,7 @@
                          x-transition:leave="transition ease-in duration-75"
                          x-transition:leave-start="transform opacity-100 scale-100"
                          x-transition:leave-end="transform opacity-0 scale-95"
-                         class="absolute top-16 right-4 mt-2 w-48 bg-white rounded-md shadow-lg py-1 z-50">
+                         class="absolute top-16 right-0 mt-2 w-56 bg-white rounded-md shadow-lg py-1 z-50 mr-4">
                         <a href="/" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">Dashboard</a>
                         <a href="/search" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">Search Albums</a>
                         <a href="/albums" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">My Albums</a>

--- a/templates/components/rating_buttons.html
+++ b/templates/components/rating_buttons.html
@@ -1,13 +1,13 @@
 <!-- Color-coded Rating Buttons Component -->
 <!-- Usage: Set track_id and current_rating variables before including this template -->
 
-<div class="rating-buttons flex flex-wrap gap-2" x-data="ratingButtons({{ track_id }}, {{ current_rating or 'null' }})">
+<div class="rating-buttons flex flex-wrap gap-1.5 sm:gap-2" x-data="ratingButtons({{ track_id }}, {{ current_rating or 'null' }})">
     <!-- Skip (0.0) - Red -->
     <div class="tooltip-trigger relative">
         <button 
             @click="setRating(0.0)"
             :class="{ 'selected': currentRating === 0.0 }"
-            class="rating-button rating-button-skip px-3 py-2 rounded-md text-sm font-medium min-w-[80px]"
+            class="rating-button rating-button-skip px-3 py-2.5 sm:py-2 rounded-md text-xs sm:text-sm font-medium min-w-[70px] sm:min-w-[80px] min-h-[44px] sm:min-h-0"
             :disabled="saving"
             hx-put="/api/v1/tracks/{{ track_id }}/rating"
             hx-vals='{"rating": 0.0}'
@@ -33,7 +33,7 @@
         <button 
             @click="setRating(0.33)"
             :class="{ 'selected': currentRating === 0.33 }"
-            class="rating-button rating-button-filler px-3 py-2 rounded-md text-sm font-medium min-w-[80px]"
+            class="rating-button rating-button-filler px-3 py-2.5 sm:py-2 rounded-md text-xs sm:text-sm font-medium min-w-[70px] sm:min-w-[80px] min-h-[44px] sm:min-h-0"
             :disabled="saving"
             hx-put="/api/v1/tracks/{{ track_id }}/rating"
             hx-vals='{"rating": 0.33}'
@@ -59,7 +59,7 @@
         <button 
             @click="setRating(0.67)"
             :class="{ 'selected': currentRating === 0.67 }"
-            class="rating-button rating-button-good px-3 py-2 rounded-md text-sm font-medium min-w-[80px]"
+            class="rating-button rating-button-good px-3 py-2.5 sm:py-2 rounded-md text-xs sm:text-sm font-medium min-w-[70px] sm:min-w-[80px] min-h-[44px] sm:min-h-0"
             :disabled="saving"
             hx-put="/api/v1/tracks/{{ track_id }}/rating"
             hx-vals='{"rating": 0.67}'
@@ -85,7 +85,7 @@
         <button 
             @click="setRating(1.0)"
             :class="{ 'selected': currentRating === 1.0 }"
-            class="rating-button rating-button-standout px-3 py-2 rounded-md text-sm font-medium min-w-[80px]"
+            class="rating-button rating-button-standout px-3 py-2.5 sm:py-2 rounded-md text-xs sm:text-sm font-medium min-w-[70px] sm:min-w-[80px] min-h-[44px] sm:min-h-0"
             :disabled="saving"
             hx-put="/api/v1/tracks/{{ track_id }}/rating"
             hx-vals='{"rating": 1.0}'

--- a/templates/components/search_results.html
+++ b/templates/components/search_results.html
@@ -144,14 +144,6 @@
                             </span>
                         </button>
                         
-                        <button @click="console.log('Show details for album:', $el.closest('[data-album-title]').dataset.albumTitle)"
-                                class="inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 transition-colors">
-                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-                            </svg>
-                            Details
-                        </button>
-                        
                         <a href="https://musicbrainz.org/release/{{ album.musicbrainz_id }}" 
                            target="_blank"
                            class="inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 transition-colors">

--- a/templates/index.html
+++ b/templates/index.html
@@ -7,89 +7,102 @@
 {% block content %}
 <div class="max-w-7xl mx-auto">
     <!-- Welcome Header -->
-    <div class="text-center mb-12">
-        <h1 class="text-4xl font-bold text-gray-900 mb-4">Welcome to Tracklist</h1>
-        <p class="text-xl text-gray-600 max-w-3xl mx-auto">
-            Your personal music album rating system. Rate and track your favorite albums with precision.
+    <div class="text-center mb-8 md:mb-12 mobile-compact-header">
+        <h1 class="text-2xl sm:text-3xl md:text-4xl font-bold text-gray-900 mb-2 md:mb-4">Welcome to Tracklist</h1>
+        <p class="text-sm sm:text-base md:text-xl text-gray-600 max-w-3xl mx-auto px-4 md:px-0">
+            Your personal music album rating system.
+            <span class="hidden sm:inline"> Rate and track your favorite albums with precision.</span>
         </p>
     </div>
     
     <!-- Quick Actions -->
-    <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-12">
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-3 sm:gap-4 md:gap-6 mb-8 md:mb-12 px-4 md:px-0">
         <!-- Search Albums -->
         <a href="/search" class="group block">
-            <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6 hover:shadow-md hover:border-blue-300 transition-all duration-200">
-                <div class="flex items-center justify-between mb-4">
-                    <div class="flex items-center justify-center w-12 h-12 bg-blue-100 rounded-lg group-hover:bg-blue-200 transition-colors">
-                        <svg class="w-6 h-6 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path>
-                        </svg>
+            <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-4 md:p-6 hover:shadow-md hover:border-blue-300 transition-all duration-200 mobile-action-card flex">
+                <div class="flex-1">
+                    <div class="flex items-center mb-3 md:mb-4">
+                        <div class="flex items-center justify-center w-10 h-10 md:w-12 md:h-12 bg-blue-100 rounded-lg group-hover:bg-blue-200 transition-colors mobile-icon-box">
+                            <svg class="w-6 h-6 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path>
+                            </svg>
+                        </div>
                     </div>
+                    <h3 class="text-base md:text-lg font-semibold text-gray-900 mb-1 md:mb-2">Search Albums</h3>
+                    <p class="text-xs sm:text-sm md:text-base text-gray-600">Find albums to rate from MusicBrainz</p>
+                </div>
+                <div class="flex items-center ml-3">
                     <svg class="w-5 h-5 text-gray-400 group-hover:text-blue-500 transition-colors" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
                     </svg>
                 </div>
-                <h3 class="text-lg font-semibold text-gray-900 mb-2">Search Albums</h3>
-                <p class="text-gray-600">Find albums to rate from the MusicBrainz DB</p>
             </div>
         </a>
         
         <!-- My Albums -->
         <a href="/albums" class="group block">
-            <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6 hover:shadow-md hover:border-green-300 transition-all duration-200">
-                <div class="flex items-center justify-between mb-4">
-                    <div class="flex items-center justify-center w-12 h-12 bg-green-100 rounded-lg group-hover:bg-green-200 transition-colors">
-                        <svg class="w-6 h-6 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"></path>
-                        </svg>
+            <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-4 md:p-6 hover:shadow-md hover:border-green-300 transition-all duration-200 mobile-action-card flex">
+                <div class="flex-1">
+                    <div class="flex items-center mb-3 md:mb-4">
+                        <div class="flex items-center justify-center w-10 h-10 md:w-12 md:h-12 bg-green-100 rounded-lg group-hover:bg-green-200 transition-colors mobile-icon-box">
+                            <svg class="w-6 h-6 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"></path>
+                            </svg>
+                        </div>
                     </div>
+                    <h3 class="text-base md:text-lg font-semibold text-gray-900 mb-1 md:mb-2">My Albums</h3>
+                    <p class="text-xs sm:text-sm md:text-base text-gray-600">View and manage your library</p>
+                </div>
+                <div class="flex items-center ml-3">
                     <svg class="w-5 h-5 text-gray-400 group-hover:text-green-500 transition-colors" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
                     </svg>
                 </div>
-                <h3 class="text-lg font-semibold text-gray-900 mb-2">My Albums</h3>
-                <p class="text-gray-600">View and manage your rated albums library</p>
             </div>
         </a>
         
         <!-- Statistics -->
         <a href="/stats" class="group block">
-            <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6 hover:shadow-md hover:border-purple-300 transition-all duration-200">
-                <div class="flex items-center justify-between mb-4">
-                    <div class="flex items-center justify-center w-12 h-12 bg-purple-100 rounded-lg group-hover:bg-purple-200 transition-colors">
-                        <svg class="w-6 h-6 text-purple-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"></path>
-                        </svg>
+            <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-4 md:p-6 hover:shadow-md hover:border-purple-300 transition-all duration-200 mobile-action-card flex">
+                <div class="flex-1">
+                    <div class="flex items-center mb-3 md:mb-4">
+                        <div class="flex items-center justify-center w-10 h-10 md:w-12 md:h-12 bg-purple-100 rounded-lg group-hover:bg-purple-200 transition-colors mobile-icon-box">
+                            <svg class="w-6 h-6 text-purple-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"></path>
+                            </svg>
+                        </div>
                     </div>
+                    <h3 class="text-base md:text-lg font-semibold text-gray-900 mb-1 md:mb-2">Your Stats</h3>
+                    <p class="text-xs sm:text-sm md:text-base text-gray-600">View statistics and insights</p>
+                </div>
+                <div class="flex items-center ml-3">
                     <svg class="w-5 h-5 text-gray-400 group-hover:text-purple-500 transition-colors" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
                     </svg>
                 </div>
-                <h3 class="text-lg font-semibold text-gray-900 mb-2">Your Stats</h3>
-                <p class="text-gray-600">View detailed statistics and insights</p>
             </div>
         </a>
     </div>
     
     <!-- In Progress Albums -->
-    <div class="mb-12" id="in-progress-section">
-        <div class="flex justify-between items-center mb-6">
-            <h2 class="text-2xl font-bold text-gray-900">In Progress</h2>
+    <div class="mb-8 md:mb-12 mobile-section-spacing px-4 md:px-0" id="in-progress-section">
+        <div class="flex justify-between items-center mb-4 md:mb-6 mobile-section-header">
+            <h2 class="text-xl md:text-2xl font-bold text-gray-900">In Progress</h2>
             <a href="/albums?filter=in-progress" class="text-blue-600 hover:text-blue-800 text-sm font-medium">View all →</a>
         </div>
         
         <div id="in-progress-albums" 
-             hx-get="/api/v1/albums?limit=6&rated=false&sort=created_desc" 
+             hx-get="/api/v1/albums?limit=3&rated=false&sort=created_desc" 
              hx-trigger="load"
              hx-target="this"
              hx-swap="none"
              hx-indicator="#in-progress-loading">
             
             <!-- Loading State -->
-            <div id="in-progress-loading" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-                {% for i in range(6) %}
-                <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
-                    <div class="loading-skeleton h-20 w-20 rounded-lg mb-4"></div>
+            <div id="in-progress-loading" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3 md:gap-6">
+                {% for i in range(3) %}
+                <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-4 md:p-6 mobile-hide-skeleton">
+                    <div class="loading-skeleton h-12 w-12 md:h-20 md:w-20 rounded-lg mb-3 md:mb-4"></div>
                     <div class="loading-skeleton h-4 w-full mb-2"></div>
                     <div class="loading-skeleton h-4 w-3/4 mb-4"></div>
                     <div class="loading-skeleton h-2 w-full"></div>
@@ -100,24 +113,24 @@
     </div>
     
     <!-- Recently Rated Albums -->
-    <div class="mb-12" id="recently-rated-section">
-        <div class="flex justify-between items-center mb-6">
-            <h2 class="text-2xl font-bold text-gray-900">Recently Rated</h2>
+    <div class="mb-8 md:mb-12 mobile-section-spacing px-4 md:px-0" id="recently-rated-section">
+        <div class="flex justify-between items-center mb-4 md:mb-6 mobile-section-header">
+            <h2 class="text-xl md:text-2xl font-bold text-gray-900">Recently Rated</h2>
             <a href="/albums?filter=completed" class="text-blue-600 hover:text-blue-800 text-sm font-medium">View all →</a>
         </div>
         
         <div id="recently-rated-albums" 
-             hx-get="/api/v1/albums?limit=6&rated=true&sort=rated_desc" 
+             hx-get="/api/v1/albums?limit=3&rated=true&sort=rated_desc" 
              hx-trigger="load"
              hx-target="this"
              hx-swap="none"
              hx-indicator="#recently-rated-loading">
             
             <!-- Loading State -->
-            <div id="recently-rated-loading" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-                {% for i in range(6) %}
-                <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
-                    <div class="loading-skeleton h-20 w-20 rounded-lg mb-4"></div>
+            <div id="recently-rated-loading" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3 md:gap-6">
+                {% for i in range(3) %}
+                <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-4 md:p-6 mobile-hide-skeleton">
+                    <div class="loading-skeleton h-12 w-12 md:h-20 md:w-20 rounded-lg mb-3 md:mb-4"></div>
                     <div class="loading-skeleton h-4 w-full mb-2"></div>
                     <div class="loading-skeleton h-4 w-3/4 mb-4"></div>
                     <div class="loading-skeleton h-2 w-full"></div>
@@ -129,15 +142,21 @@
     
     <!-- Getting Started Guide -->
     <div id="getting-started-guide"
-         class="bg-gradient-to-r from-blue-50 to-indigo-50 rounded-lg border border-blue-200 p-8 mb-12" 
+         class="bg-gradient-to-r from-blue-50 to-indigo-50 rounded-lg border border-blue-200 p-4 sm:p-6 md:p-8 mb-8 md:mb-12 mx-4 md:mx-0" 
          x-data="{ dismissed: localStorage.getItem('guide-dismissed') === 'true' }" 
          x-show="!dismissed"
          style="display: none;">
         
-        <div class="flex justify-between items-start mb-6">
+        <div class="flex justify-between items-start mb-4 md:mb-6">
             <div>
-                <h3 class="text-xl font-semibold text-blue-900 mb-2">🚀 Getting Started</h3>
-                <p class="text-blue-800">New to Tracklist? Here's how to get the most out of your album rating experience.</p>
+                <h3 class="text-lg md:text-xl font-semibold text-blue-900 mb-1 md:mb-2">🚀 Getting Started</h3>
+                <p class="text-sm md:text-base text-blue-800 hidden sm:block">New to Tracklist? Here's how to get the most out of your album rating experience.</p>
+                <button onclick="toggleMobileGuide()" class="sm:hidden text-blue-600 text-sm font-medium">
+                    <span id="guide-toggle-text">Show steps</span>
+                    <svg id="guide-toggle-icon" class="inline-block w-4 h-4 ml-1 transform transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+                    </svg>
+                </button>
             </div>
             <button @click="dismissed = true; localStorage.setItem('guide-dismissed', 'true')" 
                     class="text-blue-400 hover:text-blue-600">
@@ -147,80 +166,88 @@
             </button>
         </div>
         
-        <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
-            <div class="flex items-start space-x-3">
-                <div class="flex-shrink-0 w-8 h-8 bg-blue-600 text-white rounded-full flex items-center justify-center text-sm font-semibold">1</div>
+        <div id="guide-steps" class="grid grid-cols-1 md:grid-cols-3 gap-3 md:gap-6 mobile-collapsible sm:!max-height-none sm:!overflow-visible">
+            <div class="flex items-start space-x-2 md:space-x-3">
+                <div class="flex-shrink-0 w-6 h-6 md:w-8 md:h-8 bg-blue-600 text-white rounded-full flex items-center justify-center text-xs md:text-sm font-semibold">1</div>
                 <div>
-                    <h4 class="font-medium text-blue-900 mb-1">Search for Albums</h4>
-                    <p class="text-sm text-blue-800">Use our search to find albums from MusicBrainz's extensive database</p>
+                    <h4 class="font-medium text-blue-900 mb-0.5 md:mb-1 text-sm md:text-base">Search for Albums</h4>
+                    <p class="text-xs md:text-sm text-blue-800">Find albums from MusicBrainz database</p>
                 </div>
             </div>
             
-            <div class="flex items-start space-x-3">
-                <div class="flex-shrink-0 w-8 h-8 bg-blue-600 text-white rounded-full flex items-center justify-center text-sm font-semibold">2</div>
+            <div class="flex items-start space-x-2 md:space-x-3">
+                <div class="flex-shrink-0 w-6 h-6 md:w-8 md:h-8 bg-blue-600 text-white rounded-full flex items-center justify-center text-xs md:text-sm font-semibold">2</div>
                 <div>
-                    <h4 class="font-medium text-blue-900 mb-1">Rate Track by Track</h4>
-                    <p class="text-sm text-blue-800">Use our 4-point scale: Skip, Filler, Good, or Standout for each track</p>
+                    <h4 class="font-medium text-blue-900 mb-0.5 md:mb-1 text-sm md:text-base">Rate Track by Track</h4>
+                    <p class="text-xs md:text-sm text-blue-800">Use 4-point scale for each track</p>
                 </div>
             </div>
             
-            <div class="flex items-start space-x-3">
-                <div class="flex-shrink-0 w-8 h-8 bg-blue-600 text-white rounded-full flex items-center justify-center text-sm font-semibold">3</div>
+            <div class="flex items-start space-x-2 md:space-x-3">
+                <div class="flex-shrink-0 w-6 h-6 md:w-8 md:h-8 bg-blue-600 text-white rounded-full flex items-center justify-center text-xs md:text-sm font-semibold">3</div>
                 <div>
-                    <h4 class="font-medium text-blue-900 mb-1">Get Your Score</h4>
-                    <p class="text-sm text-blue-800">Submit when done to get a calculated album score out of 100</p>
+                    <h4 class="font-medium text-blue-900 mb-0.5 md:mb-1 text-sm md:text-base">Get Your Score</h4>
+                    <p class="text-xs md:text-sm text-blue-800">Get calculated album score out of 100</p>
                 </div>
             </div>
         </div>
     </div>
     
     <!-- Rating Scale Reference -->
-    <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
-        <h3 class="text-lg font-semibold text-gray-900 mb-4">🎵 Rating Scale Reference</h3>
+    <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-4 md:p-6 mx-4 md:mx-0">
+        <h3 class="text-base md:text-lg font-semibold text-gray-900 mb-3 md:mb-4">🎵 Rating Scale</h3>
         
-        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-            <div class="flex items-center space-x-3 p-3 bg-red-50 rounded-lg border border-red-100">
-                <div class="w-8 h-8 bg-rating-skip rounded flex items-center justify-center text-white text-sm font-bold">0</div>
+        <div class="grid grid-cols-2 lg:grid-cols-4 gap-2 md:gap-4 mobile-rating-grid">
+            <div class="flex items-center space-x-2 md:space-x-3 p-2 md:p-3 bg-red-50 rounded-lg border border-red-100 mobile-rating-item">
+                <div class="w-7 h-7 md:w-8 md:h-8 bg-rating-skip rounded flex items-center justify-center text-white text-xs md:text-sm font-bold rating-icon">0</div>
                 <div>
-                    <div class="font-medium text-red-800">Skip (0.0)</div>
-                    <div class="text-xs text-red-600">Never want to hear</div>
+                    <div class="font-medium text-red-800 text-sm md:text-base rating-label">Skip</div>
+                    <div class="text-xs text-red-600 hidden sm:block rating-desc">Never hear</div>
                 </div>
             </div>
             
-            <div class="flex items-center space-x-3 p-3 bg-amber-50 rounded-lg border border-amber-100">
-                <div class="w-8 h-8 bg-rating-filler rounded flex items-center justify-center text-white text-sm font-bold">⅓</div>
+            <div class="flex items-center space-x-2 md:space-x-3 p-2 md:p-3 bg-amber-50 rounded-lg border border-amber-100 mobile-rating-item">
+                <div class="w-7 h-7 md:w-8 md:h-8 bg-rating-filler rounded flex items-center justify-center text-white text-xs md:text-sm font-bold rating-icon">⅓</div>
                 <div>
-                    <div class="font-medium text-amber-800">Filler (0.33)</div>
-                    <div class="text-xs text-amber-600">Tolerable, won't skip</div>
+                    <div class="font-medium text-amber-800 text-sm md:text-base rating-label">Filler</div>
+                    <div class="text-xs text-amber-600 hidden sm:block rating-desc">Won't skip</div>
                 </div>
             </div>
             
-            <div class="flex items-center space-x-3 p-3 bg-green-50 rounded-lg border border-green-100">
-                <div class="w-8 h-8 bg-rating-good rounded flex items-center justify-center text-white text-sm font-bold">⅔</div>
+            <div class="flex items-center space-x-2 md:space-x-3 p-2 md:p-3 bg-green-50 rounded-lg border border-green-100 mobile-rating-item">
+                <div class="w-7 h-7 md:w-8 md:h-8 bg-rating-good rounded flex items-center justify-center text-white text-xs md:text-sm font-bold rating-icon">⅔</div>
                 <div>
-                    <div class="font-medium text-green-800">Good (0.67)</div>
-                    <div class="text-xs text-green-600">Playlist-worthy</div>
+                    <div class="font-medium text-green-800 text-sm md:text-base rating-label">Good</div>
+                    <div class="text-xs text-green-600 hidden sm:block rating-desc">Playlist</div>
                 </div>
             </div>
             
-            <div class="flex items-center space-x-3 p-3 bg-green-100 rounded-lg border border-green-200">
-                <div class="w-8 h-8 bg-rating-standout rounded flex items-center justify-center text-white text-sm font-bold">1</div>
+            <div class="flex items-center space-x-2 md:space-x-3 p-2 md:p-3 bg-green-100 rounded-lg border border-green-200 mobile-rating-item">
+                <div class="w-7 h-7 md:w-8 md:h-8 bg-rating-standout rounded flex items-center justify-center text-white text-xs md:text-sm font-bold rating-icon">1</div>
                 <div>
-                    <div class="font-medium text-green-900">Standout (1.0)</div>
-                    <div class="text-xs text-green-700">Album highlights</div>
+                    <div class="font-medium text-green-900 text-sm md:text-base rating-label">Standout</div>
+                    <div class="text-xs text-green-700 hidden sm:block rating-desc">Highlights</div>
                 </div>
             </div>
         </div>
         
-        <div class="mt-4 p-3 bg-blue-50 rounded-lg border border-blue-100">
-            <div class="flex items-start space-x-2">
-                <svg class="w-4 h-4 text-blue-500 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-                </svg>
-                <div class="text-sm text-blue-800">
-                    <strong>Final Score Formula:</strong> Floor((Average Rating × 10) + Album Bonus) × 10
+        <div class="mt-3 md:mt-4 p-2 md:p-3 bg-blue-50 rounded-lg border border-blue-100">
+            <details class="group">
+                <summary class="flex items-center space-x-2 cursor-pointer select-none">
+                    <svg class="w-3 h-3 md:w-4 md:h-4 text-blue-500 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+                    </svg>
+                    <span class="text-xs md:text-sm text-blue-800 font-medium">Score Formula</span>
+                    <svg class="w-3 h-3 ml-auto transform transition-transform group-open:rotate-180" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+                    </svg>
+                </summary>
+                <div class="mt-2 text-xs md:text-sm text-blue-800 pl-5 md:pl-6">
+                    Floor((Average × 10) + Bonus) × 10
                     <br>
-                    <span class="text-xs">Album bonus is typically +0.33 and can be configured in settings</span>
+                    <span class="text-xs">Album bonus: +0.33 (configurable)</span>
+                </div>
+            </details>
                 </div>
             </div>
         </div>
@@ -229,6 +256,23 @@
 
 <!-- Load user stats and recent activity -->
 <script>
+// Mobile guide toggle function
+function toggleMobileGuide() {
+    const steps = document.getElementById('guide-steps');
+    const toggleText = document.getElementById('guide-toggle-text');
+    const toggleIcon = document.getElementById('guide-toggle-icon');
+    
+    if (steps.classList.contains('expanded')) {
+        steps.classList.remove('expanded');
+        toggleText.textContent = 'Show steps';
+        toggleIcon.classList.remove('rotate-180');
+    } else {
+        steps.classList.add('expanded');
+        toggleText.textContent = 'Hide steps';
+        toggleIcon.classList.add('rotate-180');
+    }
+}
+
 // Score color utility function
 function getScoreColorClass(score) {
     console.log('getScoreColorClass called with:', score, typeof score);
@@ -359,6 +403,11 @@ function checkAndShowGettingStarted() {
 function renderAlbumSection(data, containerId, sectionType) {
     const container = document.getElementById(containerId);
     const albums = data.albums || [];
+    const isMobile = window.innerWidth <= 640;
+    const albumLimit = isMobile ? 3 : 6;
+    
+    // Show only limited albums on mobile
+    const displayAlbums = albums.slice(0, albumLimit);
     
     if (albums.length === 0) {
         if (sectionType === 'recently-rated') {
@@ -387,7 +436,62 @@ function renderAlbumSection(data, containerId, sectionType) {
         return;
     }
     
-    const albumCards = albums.map(album => `
+    // Generate album cards with mobile-optimized layout
+    const albumCards = displayAlbums.map(album => {
+        // Mobile layout (compact horizontal card - clickable)
+        if (isMobile) {
+            const url = album.is_rated ? `/albums/${album.id}/completed` : `/albums/${album.id}/rate`;
+            return `
+        <a href="${url}" class="block bg-white rounded-lg shadow-sm border border-gray-200 hover:shadow-md hover:border-gray-300 transition-all duration-200 active:scale-[0.98]">
+            <div class="flex items-center p-3">
+                <!-- Compact Album Art -->
+                ${album.cover_art_url ? `
+                    <div class="w-12 h-12 rounded-lg overflow-hidden flex-shrink-0">
+                        <img src="${album.cover_art_url}" 
+                             alt="${album.title} cover" 
+                             class="w-full h-full object-cover"
+                             onerror="this.style.display='none'; this.nextElementSibling.style.display='flex';">
+                        <div class="w-12 h-12 bg-gradient-to-br from-gray-200 to-gray-300 rounded-lg flex items-center justify-center" style="display:none;">
+                            <svg class="w-6 h-6 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zm12-3c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zM9 10l12-3"></path>
+                            </svg>
+                        </div>
+                    </div>
+                ` : `
+                    <div class="w-12 h-12 bg-gradient-to-br from-gray-200 to-gray-300 rounded-lg flex items-center justify-center flex-shrink-0">
+                        <svg class="w-6 h-6 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zm12-3c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zM9 10l12-3"></path>
+                        </svg>
+                    </div>
+                `}
+                
+                <!-- Album Info -->
+                <div class="flex-1 min-w-0 ml-3">
+                    <h3 class="font-semibold text-gray-900 text-sm truncate" title="${album.title}">${album.title}</h3>
+                    <p class="text-xs text-gray-600 truncate mb-1" title="${album.artist}">${album.artist}</p>
+                    
+                    <!-- Status -->
+                    <div class="flex items-center">
+                        ${album.is_rated ? `
+                            <span class="text-xs font-medium text-green-700">✓ Completed</span>
+                            <span class="text-sm font-bold ${getScoreColorClass(album.rating_score)} ml-auto mr-2">${album.rating_score}/100</span>
+                        ` : `
+                            <span class="text-xs font-medium text-amber-700">⏳ In Progress</span>
+                        `}
+                    </div>
+                </div>
+                
+                <!-- Arrow indicator -->
+                <svg class="w-4 h-4 text-gray-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
+                </svg>
+            </div>
+        </a>
+            `;
+        }
+        
+        // Desktop layout (original card style)
+        return `
         <div class="bg-white rounded-lg shadow-sm border border-gray-200 hover:shadow-md transition-all duration-200">
             <div class="p-6">
                 <!-- Album Art -->
@@ -447,9 +551,40 @@ function renderAlbumSection(data, containerId, sectionType) {
                 </div>
             </div>
         </div>
-    `).join('');
+    `;
+    }).join('');
     
-    container.innerHTML = `<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">${albumCards}</div>`;
+    // Add 'Show more' button on mobile if there are more albums
+    const showMoreButton = (isMobile && albums.length > albumLimit) ? `
+        <div class="mt-4 text-center">
+            <button onclick="loadMoreAlbums('${containerId}', '${sectionType}')" 
+                    class="text-sm text-blue-600 hover:text-blue-800 font-medium">
+                Show ${albums.length - albumLimit} more →
+            </button>
+        </div>
+    ` : '';
+    
+    container.innerHTML = `
+        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3 md:gap-6">
+            ${albumCards}
+        </div>
+        ${showMoreButton}
+    `;
+}
+
+// Load more albums function
+function loadMoreAlbums(containerId, sectionType) {
+    const url = sectionType === 'in-progress' 
+        ? '/api/v1/albums?limit=20&rated=false&sort=created_desc'
+        : '/api/v1/albums?limit=20&rated=true&sort=rated_desc';
+    
+    fetch(url)
+        .then(response => response.json())
+        .then(data => {
+            // Re-render with all albums
+            renderAlbumSection(data, containerId, sectionType);
+        })
+        .catch(error => console.error('Error loading more albums:', error));
 }
 </script>
 {% endblock %}

--- a/templates/search.html
+++ b/templates/search.html
@@ -113,7 +113,7 @@
                                    id="mbid"
                                    x-model="mbid"
                                    @input="clearOtherFields(); validateMBID()"
-                                   class="block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
+                                   class="block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 py-2 px-3 text-base md:text-sm"
                                    :class="{'border-red-300': mbidError}"
                                    placeholder="e.g., 7f9e8590-5d8f-4234-8b23-5f1234567890"
                                    pattern="[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}">
@@ -125,10 +125,10 @@
                     <!-- Search Settings -->
                     <div>
                         <h4 class="text-sm font-semibold text-gray-800 mb-3">Display Settings</h4>
-                        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                        <div class="grid grid-cols-1 md:grid-cols-2 gap-3 md:gap-4">
                             <div>
                                 <label for="limit" class="block text-sm font-medium text-gray-700 mb-1">Results per page</label>
-                                <select name="limit" id="limit" class="block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm">
+                                <select name="limit" id="limit" class="block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 py-2 px-3 text-base md:text-sm">
                                     <option value="10">10 results</option>
                                     <option value="25" selected>25 results</option>
                                     <option value="50">50 results</option>
@@ -137,7 +137,7 @@
                             <div>
                                 <label for="offset" class="block text-sm font-medium text-gray-700 mb-1">Start from result</label>
                                 <input type="number" name="offset" id="offset" value="0" min="0" step="10"
-                                       class="block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm">
+                                       class="block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 py-2 px-3 text-base md:text-sm">
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
  - Responsive album artwork sizing on rating page (96px mobile → 192px desktop)
  - Increase rating button touch targets to 44px minimum on mobile
  - Make mobile album cards fully clickable with arrow indicators
  - Fix navigation menu positioning and width on mobile
  - Optimize form input sizing across all pages
  - Improve Quick Actions card layout with centered arrows
  - Add responsive text sizing throughout
  - Reduce visual clutter on mobile with compact layouts