### PR TITLE
Fix artwork cache bypass - API now returns cached URLs when available

### DIFF
--- a/app/rating_service.py
+++ b/app/rating_service.py
@@ -463,6 +463,10 @@ class RatingService:
         settings = db.query(UserSettings).filter(UserSettings.user_id == 1).first()
         current_album_bonus = settings.album_bonus if settings else album.album_bonus
         
+        # Get cached artwork URL if available
+        from .template_utils import get_artwork_url
+        cached_artwork_url = get_artwork_url(album, size='medium')
+        
         response = {
             "id": album.id,
             "musicbrainz_id": album.musicbrainz_id,
@@ -476,7 +480,7 @@ class RatingService:
             "genre": album.genre,
             "total_tracks": album.total_tracks,
             "total_duration_ms": album.total_duration_ms,
-            "cover_art_url": album.cover_art_url,
+            "cover_art_url": cached_artwork_url,
             "album_bonus": current_album_bonus,
             "is_rated": album.is_rated,
             "rating_score": album.rating_score,
@@ -502,6 +506,10 @@ class RatingService:
 
     def _format_album_summary(self, album: Album) -> Dict[str, Any]:
         """Format album summary for lists"""
+        # Get cached artwork URL if available
+        from .template_utils import get_artwork_url
+        cached_artwork_url = get_artwork_url(album, size='medium')
+        
         return {
             "id": album.id,
             "musicbrainz_id": album.musicbrainz_id,
@@ -509,7 +517,7 @@ class RatingService:
             "artist": album.artist.name,
             "artist_id": album.artist.id,
             "year": album.release_year,
-            "cover_art_url": album.cover_art_url,
+            "cover_art_url": cached_artwork_url,
             "is_rated": album.is_rated,
             "rating_score": album.rating_score,
             "rated_at": album.rated_at.isoformat() if album.rated_at else None

--- a/app/reporting_service.py
+++ b/app/reporting_service.py
@@ -186,13 +186,17 @@ class ReportingService:
 
     def _format_album_summary(self, album: Album) -> Dict[str, Any]:
         """Format album data for summary response"""
+        # Get cached artwork URL if available
+        from .template_utils import get_artwork_url
+        cached_artwork_url = get_artwork_url(album, size='medium')
+        
         return {
             "id": album.id,
             "name": album.name,
             "artist": album.artist.name if album.artist else "Unknown Artist",
             "year": album.release_year,
             "score": album.rating_score,
-            "cover_art_url": album.cover_art_url,
+            "cover_art_url": cached_artwork_url,
             "rated_at": album.rated_at.isoformat() if album.rated_at else None
         }
 
@@ -212,12 +216,16 @@ class ReportingService:
             if total_tracks > 0 else 0
         )
 
+        # Get cached artwork URL if available
+        from .template_utils import get_artwork_url
+        cached_artwork_url = get_artwork_url(album, size='medium')
+        
         return {
             "id": album.id,
             "name": album.name,
             "artist": album.artist.name if album.artist else "Unknown Artist",
             "year": album.release_year,
-            "cover_art_url": album.cover_art_url,
+            "cover_art_url": cached_artwork_url,
             "progress": {
                 "rated_tracks": rated_tracks,
                 "total_tracks": total_tracks,
@@ -474,6 +482,10 @@ class ReportingService:
             if track.track_rating is not None
         ]
 
+        # Get cached artwork URL if available
+        from .template_utils import get_artwork_url
+        cached_artwork_url = get_artwork_url(album, size='medium')
+
         return {
             "id": album.id,
             "name": album.name,
@@ -481,7 +493,7 @@ class ReportingService:
             "artist_id": album.artist_id,
             "year": album.release_year,
             "score": album.rating_score,
-            "cover_art_url": album.cover_art_url,
+            "cover_art_url": cached_artwork_url,
             "rated_at": album.rated_at.isoformat() if album.rated_at else None,
             "total_tracks": len(album.tracks),
             "average_track_rating": round(sum(track_ratings) / len(track_ratings), 2) if track_ratings else 0,
@@ -613,6 +625,9 @@ class ReportingService:
                 .all()
             )
 
+            # Get cached artwork URLs if available
+            from .template_utils import get_artwork_url
+            
             result = {
                 "artist_name": top_artist.name,
                 "artist_id": top_artist.id,
@@ -624,7 +639,7 @@ class ReportingService:
                         "name": album.name,
                         "year": album.release_year,
                         "score": album.rating_score,
-                        "cover_art_url": album.cover_art_url,
+                        "cover_art_url": get_artwork_url(album, size='medium'),
                         "rated_at": album.rated_at.isoformat() if album.rated_at else None
                     }
                     for album in top_albums
@@ -798,6 +813,9 @@ class ReportingService:
                     .all()
                 )
 
+                # Get cached artwork URLs if available
+                from .template_utils import get_artwork_url
+                
                 artist_data = {
                     "artist_id": artist_stat.id,
                     "artist_name": artist_stat.name,
@@ -809,7 +827,7 @@ class ReportingService:
                             "name": album.name,
                             "year": album.release_year,
                             "score": album.rating_score,
-                            "cover_art_url": album.cover_art_url
+                            "cover_art_url": get_artwork_url(album, size='medium')
                         }
                         for album in top_albums
                     ],


### PR DESCRIPTION
  Previously API responses always returned external Cover Art Archive URLs even when
  artwork was cached locally. Now checks cache first, reducing external API calls.