### PR TITLE
fix: mobile menu dropdown transparency on rating pages

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -5,6 +5,13 @@
     display: none !important; 
 }
 
+/* Mobile Menu - ensure opaque background */
+.mobile-menu-dropdown {
+    background-color: rgb(var(--color-surface)) !important;
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+}
+
 /* HTMX Loading States */
 .htmx-indicator {
     display: none;

--- a/templates/base.html
+++ b/templates/base.html
@@ -161,7 +161,7 @@
                         
                         <!-- Mobile Menu Dropdown -->
                         <div x-show="open" 
-                             style="display: none;"
+                             style="display: none; z-index: 9999;"
                              @click.away="open = false"
                              x-transition:enter="transition ease-out duration-200"
                              x-transition:enter-start="transform opacity-0 scale-95"
@@ -169,7 +169,7 @@
                              x-transition:leave="transition ease-in duration-200"
                              x-transition:leave-start="transform opacity-100 scale-100"
                              x-transition:leave-end="transform opacity-0 scale-95"
-                             class="absolute right-0 mt-2 w-56 rounded-md shadow-lg bg-surface border border-border">
+                             class="mobile-menu-dropdown absolute right-0 mt-2 w-56 rounded-md shadow-xl bg-surface border border-border">
                             <div class="py-1">
                                 <a href="/" @click="open = false" class="block px-4 py-2 text-sm text-primary hover:bg-surface-hover transition-colors duration-200">Dashboard</a>
                                 <a href="/search" @click="open = false" class="block px-4 py-2 text-sm text-primary hover:bg-surface-hover transition-colors duration-200">Search Albums</a>
@@ -192,7 +192,7 @@
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16"></path>
                             </svg>
                         </label>
-                        <div class="mobile-menu-items hidden absolute right-0 mt-2 w-56 rounded-md shadow-lg bg-surface border border-border">
+                        <div class="mobile-menu-items mobile-menu-dropdown hidden absolute right-0 mt-2 w-56 rounded-md shadow-xl bg-surface border border-border" style="z-index: 9999;">
                             <a href="/" class="block px-4 py-2 text-sm text-primary hover:bg-surface-hover transition-colors duration-200">Dashboard</a>
                             <a href="/search" class="block px-4 py-2 text-sm text-primary hover:bg-surface-hover transition-colors duration-200">Search Albums</a>
                             <a href="/albums" class="block px-4 py-2 text-sm text-primary hover:bg-surface-hover transition-colors duration-200">My Albums</a>


### PR DESCRIPTION
  - Added high z-index (9999) to ensure menu appears above all content
  - Created dedicated CSS class with opaque background and backdrop blur
  - Enhanced shadow from lg to xl for better visual separation
  - Applied fixes to both JavaScript and noscript fallback menus

  Fixes content bleeding through hamburger menu on album rating pages