### PR TITLE
fix: Properly fetch and store music genres instead of country codes

### DIFF
--- a/app/musicbrainz_client.py
+++ b/app/musicbrainz_client.py
@@ -267,8 +267,21 @@ class MusicBrainzClient:
         Returns:
             Dict containing release with complete track information
         """
-        include = ["artist-credits", "recordings", "media", "release-groups"]
+        include = ["artist-credits", "recordings", "media", "release-groups", "tags", "release-group-level-rels", "genres"]
         return await self.get_release_details(release_id, include)
+    
+    async def get_release_group_with_tags(self, release_group_id: str) -> Dict[str, Any]:
+        """
+        Get release group information including genre tags
+        
+        Args:
+            release_group_id: MusicBrainz release group ID
+            
+        Returns:
+            Dict containing release group with tags
+        """
+        params = {"inc": "tags"}
+        return await self._make_request(f"release-group/{release_group_id}", params)
 
 
 # Global client instance for dependency injection

--- a/app/musicbrainz_service.py
+++ b/app/musicbrainz_service.py
@@ -374,8 +374,57 @@ class MusicBrainzService:
 
         album["total_tracks"] = len(album["tracks"])
         album["total_duration_ms"] = total_duration if total_duration > 0 else None
+        
+        # Extract genre from release-group tags if available
+        album["genre"] = self._extract_genre_from_release(raw_data)
 
         return album
+    
+    def _extract_genre_from_release(self, release_data: Dict[str, Any]) -> Optional[str]:
+        """
+        Extract genre information from MusicBrainz release data
+        
+        Args:
+            release_data: Raw MusicBrainz release data
+            
+        Returns:
+            Comma-separated genre string or None if no genres found
+        """
+        genres = []
+        
+        # Common non-genre tags to filter out
+        non_genre_tags = {
+            'english', 'spanish', 'french', 'german', 'italian', 'japanese', 'portuguese',
+            'instrumental', 'live', 'compilation', 'studio', 'remix',
+            '1', '2', '3', '4', '5', '2/5', '3/5', '4/5', '5/5',
+            '1–9 wochen', 'explicit', 'clean', 'single', 'ep', 'lp'
+        }
+        
+        # Try to get genres from release-group tags
+        if release_data.get("release-group") and release_data["release-group"].get("tags"):
+            tags = release_data["release-group"]["tags"]
+            # Sort by count (popularity) and take top 10 to filter from
+            sorted_tags = sorted(tags, key=lambda x: x.get("count", 0), reverse=True)[:10]
+            
+            # Filter out non-genre tags and take top 5 genres
+            for tag in sorted_tags:
+                tag_name = tag.get("name", "").lower()
+                if tag_name and tag_name not in non_genre_tags and not tag_name.isdigit():
+                    genres.append(tag["name"])
+                    if len(genres) >= 5:
+                        break
+        
+        if genres:
+            # Format genres properly (capitalize, join with comma)
+            formatted_genres = []
+            for genre in genres:
+                # Basic formatting - capitalize each word
+                formatted_genre = " ".join(word.capitalize() for word in genre.split("-"))
+                formatted_genres.append(formatted_genre)
+            return ", ".join(formatted_genres)
+        
+        # Return None if no genres found
+        return None
 
     def get_cache_stats(self) -> Dict[str, Any]:
         """Get cache statistics"""

--- a/app/rating_service.py
+++ b/app/rating_service.py
@@ -142,7 +142,7 @@ class RatingService:
                 name=mb_album["title"],
                 release_year=mb_album.get("year"),
                 musicbrainz_id=musicbrainz_id,
-                genre=mb_album.get("country"),  # Temporary mapping
+                genre=mb_album.get("genre"),
                 total_tracks=mb_album["total_tracks"],
                 total_duration_ms=mb_album.get("total_duration_ms"),
                 album_bonus=album_bonus,


### PR DESCRIPTION
  Previously, the genre field was incorrectly populated with country codes
  (e.g., US, GB) instead of actual music genres due to a temporary
  mapping that was never fixed. This prevented genre-based analytics and
  reporting features.

  Changes:
  - Fix album creation to extract genres from MusicBrainz release-group tags
  - Add genre extraction method that fetches and formats tag data
  - Filter out non-genre tags (languages, ratings, etc.)
  - Add one-time migration to fix existing albums with NULL or country codes
  - Migration runs automatically on startup as background task
  - Set genre to NULL when no genre data is available

  The migration will:
  - Find all albums with NULL genres or 2-3 letter country codes
  - Fetch proper genre data from MusicBrainz API
  - Update albums with formatted genres (e.g., Rock, Alternative Rock)
  - Respect MusicBrainz rate limits (1 req/sec)
  - Log all changes for visibility

  Note: The migration function can be removed in v2.0+ once all users have
  upgraded and run the fix.