### PR TITLE
feat: Add Year End collage generation for album collections

### DIFF
--- a/app/services/collage_service.py
+++ b/app/services/collage_service.py
@@ -1,0 +1,387 @@
+"""
+Collage Service for generating album collages in Topsters format
+"""
+
+import logging
+from typing import List, Tuple, Optional, Dict, Any
+from PIL import Image, ImageDraw, ImageFont
+from io import BytesIO
+import os
+from pathlib import Path
+from sqlalchemy.orm import Session
+import asyncio
+
+try:
+    import httpx
+    HTTPX_AVAILABLE = True
+except ImportError:
+    HTTPX_AVAILABLE = False
+    logger.warning("httpx not available - direct download fallback will not work")
+
+from ..models import Album, ArtworkCache
+from .artwork_cache_service import ArtworkCacheService, get_artwork_cache_service
+
+logger = logging.getLogger(__name__)
+
+
+class CollageService:
+    """
+    Service for generating album collages in Topsters format
+    Creates visual grids of album artwork with optional ranking lists
+    """
+    
+    # Album tile size in pixels
+    TILE_SIZE = 300
+    
+    # Spacing between albums
+    SPACING = 2
+    
+    # Background color
+    BG_COLOR = (18, 18, 18)  # Dark background
+    
+    # Text color for ranking list
+    TEXT_COLOR = (255, 255, 255)
+    
+    # Ranking list width (if included)
+    RANKING_WIDTH = 500  # Increased from 400 to prevent cutoff
+    
+    # Font settings
+    FONT_SIZE = 16
+    RANKING_FONT_SIZE = 12  # Reduced from 14 for better fit
+    
+    def __init__(self):
+        """Initialize the collage service"""
+        self.artwork_cache_service = get_artwork_cache_service()
+        self.placeholder_path = Path("static/img/album-placeholder.svg")
+        
+    def calculate_grid_dimensions(self, album_count: int) -> Tuple[int, int]:
+        """
+        Calculate optimal grid dimensions for near-square layout
+        
+        Args:
+            album_count: Number of albums to include
+            
+        Returns:
+            Tuple of (columns, rows)
+        """
+        if album_count <= 0:
+            return (0, 0)
+        
+        # Calculate the square root to find the ideal square size
+        import math
+        sqrt = math.sqrt(album_count)
+        
+        # Start with the ceiling of the square root for columns
+        cols = math.ceil(sqrt)
+        
+        # Calculate rows needed
+        rows = math.ceil(album_count / cols)
+        
+        # Try to make it more square by adjusting if we have too many empty spots
+        # If we have a lot of empty spaces, try reducing columns
+        while cols > 1 and (cols - 1) * rows >= album_count:
+            cols -= 1
+            rows = math.ceil(album_count / cols)
+        
+        # Cap at 10x10 maximum
+        if cols > 10:
+            cols = 10
+            rows = math.ceil(album_count / 10)
+        
+        return (cols, rows)
+    
+    def get_placeholder_image(self) -> Image.Image:
+        """
+        Get a placeholder image for missing artwork
+        
+        Returns:
+            PIL Image object with placeholder
+        """
+        # Create a simple gray placeholder
+        placeholder = Image.new('RGB', (self.TILE_SIZE, self.TILE_SIZE), color=(60, 60, 60))
+        
+        # Add a music note icon or text
+        draw = ImageDraw.Draw(placeholder)
+        try:
+            # Try to load a basic font
+            font = ImageFont.truetype("/System/Library/Fonts/Helvetica.ttc", 48)
+        except:
+            font = ImageFont.load_default()
+        
+        # Draw "?" in center
+        text = "♪"
+        bbox = draw.textbbox((0, 0), text, font=font)
+        text_width = bbox[2] - bbox[0]
+        text_height = bbox[3] - bbox[1]
+        position = ((self.TILE_SIZE - text_width) // 2, (self.TILE_SIZE - text_height) // 2)
+        draw.text(position, text, fill=(100, 100, 100), font=font)
+        
+        return placeholder
+    
+    async def load_album_artwork(self, album: Album, db: Session) -> Image.Image:
+        """
+        Load album artwork from cache
+        
+        Args:
+            album: Album model instance
+            db: Database session
+            
+        Returns:
+            PIL Image object
+        """
+        try:
+            # Try to get the original artwork from cache
+            cache_record = db.query(ArtworkCache).filter_by(
+                album_id=album.id,
+                size_variant="original"
+            ).first()
+            
+            if cache_record and cache_record.file_path:
+                # The file_path in DB is already the full relative path (e.g., "static/artwork_cache/original/xxx.jpg")
+                image_path = Path(cache_record.file_path)
+                
+                if image_path.exists():
+                    with Image.open(image_path) as img:
+                        # Convert to RGB and resize to tile size
+                        img = img.convert('RGB')
+                        img = img.resize((self.TILE_SIZE, self.TILE_SIZE), Image.Resampling.LANCZOS)
+                        return img.copy()  # Return a copy to avoid file lock issues
+                else:
+                    logger.warning(f"Cached file not found at {image_path} for album {album.id}")
+            
+            # If no cached original, try to find any cached size and use that
+            for size in ['large', 'medium', 'small']:
+                cache_record = db.query(ArtworkCache).filter_by(
+                    album_id=album.id,
+                    size_variant=size
+                ).first()
+                
+                if cache_record and cache_record.file_path:
+                    # The file_path in DB is already the full relative path
+                    image_path = Path(cache_record.file_path)
+                    
+                    if image_path.exists():
+                        logger.info(f"Using {size} variant for album {album.id} as original not found")
+                        with Image.open(image_path) as img:
+                            img = img.convert('RGB')
+                            img = img.resize((self.TILE_SIZE, self.TILE_SIZE), Image.Resampling.LANCZOS)
+                            return img.copy()
+            
+            # If no cached artwork but we have a URL, download directly
+            if album.cover_art_url and HTTPX_AVAILABLE:
+                logger.info(f"No cached artwork found for album {album.id}, downloading from URL directly")
+                try:
+                    # Download the image directly
+                    async with httpx.AsyncClient(timeout=10.0, follow_redirects=True) as client:
+                        response = await client.get(album.cover_art_url)
+                        if response.status_code == 200:
+                            # Load the image from downloaded bytes
+                            img = Image.open(BytesIO(response.content))
+                            img = img.convert('RGB')
+                            img = img.resize((self.TILE_SIZE, self.TILE_SIZE), Image.Resampling.LANCZOS)
+                            
+                            logger.info(f"Successfully downloaded and resized artwork for album {album.id}")
+                            
+                            # Optionally try to cache it in the background (but don't wait)
+                            try:
+                                asyncio.create_task(
+                                    self.artwork_cache_service.get_or_cache_artwork(album, "original", db)
+                                )
+                            except Exception as cache_error:
+                                logger.debug(f"Could not trigger background caching: {cache_error}")
+                            
+                            return img
+                        else:
+                            logger.warning(f"Failed to download artwork for album {album.id}: HTTP {response.status_code}")
+                            
+                except Exception as download_error:
+                    logger.error(f"Error downloading artwork for album {album.id}: {download_error}")
+            
+            # Return placeholder if all else fails
+            logger.warning(f"Using placeholder for album {album.id} - no artwork available")
+            return self.get_placeholder_image()
+            
+        except Exception as e:
+            logger.error(f"Failed to load artwork for album {album.id}: {e}")
+            return self.get_placeholder_image()
+    
+    async def generate_collage(
+        self,
+        albums: List[Album],
+        db: Session,
+        include_ranking: bool = True,
+        include_scores: bool = True,
+        max_albums: Optional[int] = None,
+        title: Optional[str] = None
+    ) -> bytes:
+        """
+        Generate a collage image from a list of albums
+        
+        Args:
+            albums: List of Album objects sorted by rating
+            db: Database session
+            include_ranking: Whether to include ranking list
+            include_scores: Whether to include scores in ranking
+            max_albums: Maximum number of albums to include
+            title: Optional title for the collage
+            
+        Returns:
+            Bytes of the generated image (PNG format)
+        """
+        # Limit albums if specified
+        if max_albums:
+            albums = albums[:max_albums]
+        
+        album_count = len(albums)
+        if album_count == 0:
+            raise ValueError("No albums provided for collage generation")
+        
+        # Calculate grid dimensions
+        cols, rows = self.calculate_grid_dimensions(album_count)
+        
+        # Calculate image dimensions
+        collage_width = cols * self.TILE_SIZE + (cols - 1) * self.SPACING
+        collage_height = rows * self.TILE_SIZE + (rows - 1) * self.SPACING
+        
+        # Add space for ranking list if included
+        total_width = collage_width
+        if include_ranking:
+            total_width += self.RANKING_WIDTH + 40  # 40px padding
+        
+        # Add space for title if included
+        title_height = 60 if title else 0
+        total_height = collage_height + title_height
+        
+        # Create the base image
+        img = Image.new('RGB', (total_width, total_height), color=self.BG_COLOR)
+        draw = ImageDraw.Draw(img)
+        
+        # Load font for text
+        try:
+            # Try to load system fonts
+            title_font = ImageFont.truetype("/System/Library/Fonts/Helvetica.ttc", 32)
+            ranking_font = ImageFont.truetype("/System/Library/Fonts/Helvetica.ttc", self.RANKING_FONT_SIZE)
+        except:
+            # Fallback to default font
+            title_font = ImageFont.load_default()
+            ranking_font = ImageFont.load_default()
+        
+        # Draw title if provided
+        y_offset = 0
+        if title:
+            title_bbox = draw.textbbox((0, 0), title, font=title_font)
+            title_width = title_bbox[2] - title_bbox[0]
+            title_x = (collage_width - title_width) // 2
+            draw.text((title_x, 15), title, fill=self.TEXT_COLOR, font=title_font)
+            y_offset = title_height
+        
+        # Place albums in grid
+        logger.info(f"Generating collage with {album_count} albums in {cols}x{rows} grid")
+        
+        for idx, album in enumerate(albums):
+            # Calculate position in grid
+            row = idx // cols
+            col = idx % cols
+            
+            x = col * (self.TILE_SIZE + self.SPACING)
+            y = row * (self.TILE_SIZE + self.SPACING) + y_offset
+            
+            # Load album artwork
+            album_img = await self.load_album_artwork(album, db)
+            
+            # Paste album onto collage
+            img.paste(album_img, (x, y))
+        
+        # Add ranking list if requested
+        if include_ranking:
+            ranking_x = collage_width + 40
+            
+            # Calculate line height based on total height and number of albums
+            # We want the text to be evenly distributed across the collage height
+            line_height = 22  # Fixed line height for readability
+            
+            # Start position for the first line
+            ranking_y_start = y_offset + 10
+            
+            for idx, album in enumerate(albums):
+                rank = idx + 1
+                # Get artist name (handle both string and Artist object)
+                artist_name = album.artist.name if hasattr(album.artist, 'name') else str(album.artist)
+                # Truncate long names
+                artist_name = artist_name[:25] + "..." if len(artist_name) > 25 else artist_name
+                album_name = album.name[:30] + "..." if len(album.name) > 30 else album.name
+                
+                if include_scores and album.rating_score is not None:
+                    text = f"{rank}. {artist_name} - {album_name} ({album.rating_score}/100)"
+                else:
+                    text = f"{rank}. {artist_name} - {album_name}"
+                
+                # Simple sequential positioning - each album gets its own line
+                text_y = ranking_y_start + (idx * line_height)
+                
+                draw.text((ranking_x, text_y), text, fill=self.TEXT_COLOR, font=ranking_font)
+        
+        # Save to bytes
+        output = BytesIO()
+        img.save(output, format='PNG', optimize=True, quality=95)
+        output.seek(0)
+        
+        logger.info(f"Successfully generated collage: {total_width}x{total_height}px")
+        return output.getvalue()
+    
+    async def generate_year_collage(
+        self,
+        year: int,
+        db: Session,
+        include_ranking: bool = True,
+        include_scores: bool = True,
+        max_albums: Optional[int] = None
+    ) -> bytes:
+        """
+        Generate a collage for a specific year
+        
+        Args:
+            year: Year to generate collage for
+            db: Database session
+            include_ranking: Whether to include ranking list
+            include_scores: Whether to include scores in ranking
+            max_albums: Maximum number of albums to include
+            
+        Returns:
+            Bytes of the generated image
+        """
+        # Query albums for the year, sorted by rating
+        albums = db.query(Album).filter(
+            Album.release_year == year,
+            Album.is_rated == True
+        ).order_by(
+            Album.rating_score.desc()
+        ).all()
+        
+        if not albums:
+            raise ValueError(f"No rated albums found for year {year}")
+        
+        # Generate title
+        title = f"{year} Year End"
+        
+        return await self.generate_collage(
+            albums,
+            db,
+            include_ranking=include_ranking,
+            include_scores=include_scores,
+            max_albums=max_albums,
+            title=title
+        )
+
+
+# Singleton instance
+_collage_service_instance = None
+
+
+def get_collage_service() -> CollageService:
+    """Get or create the singleton CollageService instance"""
+    global _collage_service_instance
+    if _collage_service_instance is None:
+        _collage_service_instance = CollageService()
+        logger.info("CollageService initialized")
+    return _collage_service_instance

--- a/templates/year_albums.html
+++ b/templates/year_albums.html
@@ -13,6 +13,19 @@
                 </svg>
             </a>
             <h1 class="text-3xl font-bold text-primary">{{ year }}</h1>
+            
+            <!-- Collage Button -->
+            <button id="generate-collage-btn" 
+                    onclick="openCollageModal()"
+                    title="Generate Year End Collage"
+                    class="hidden ml-3 p-2 text-muted hover:text-accent-blue hover:bg-info-light rounded-lg transition-all duration-200 group relative self-center">
+                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"></path>
+                </svg>
+                <span class="absolute -bottom-8 left-0 text-xs bg-surface-hover text-primary px-2 py-1 rounded opacity-0 group-hover:opacity-100 transition-opacity whitespace-nowrap border border-default z-10">
+                    Year End Collage
+                </span>
+            </button>
         </div>
         <p class="text-secondary">All albums from {{ year }} in your library</p>
     </div>
@@ -276,10 +289,239 @@ function updatePaginationButton(data) {
     }
 }
 
+// Store rated albums count
+let ratedAlbumsCount = 0;
+
+// Modified loadYearAlbums to track rated albums
+async function loadYearAlbumsWithButton(offset = 0) {
+    const url = `/api/v1/albums?limit=20&offset=${offset}&year=${year}&sort=rating_desc_status`;
+    
+    try {
+        const response = await fetch(url);
+        if (response.ok) {
+            const data = await response.json();
+            
+            // Count ALL rated albums for this year (not just first page)
+            if (offset === 0) {
+                // The current 'data' already has info about this year, but only first page
+                // We need to get ALL albums to count properly
+                
+                // Check if current response has all albums or if there are more pages
+                if (data.has_more || (data.total && data.total > 20)) {
+                    // Need to fetch all albums to get accurate rated count
+                    // Use limit=100 which should be enough for most years
+                    const countUrl = `/api/v1/albums?limit=100&offset=0&year=${year}`;
+                    const countResponse = await fetch(countUrl);
+                    if (countResponse.ok) {
+                        const countData = await countResponse.json();
+                        
+                        // Count only rated albums from the full dataset
+                        if (countData.albums && Array.isArray(countData.albums)) {
+                            ratedAlbumsCount = countData.albums.filter(a => a.is_rated === true).length;
+                            console.log(`Year ${year}: Found ${ratedAlbumsCount} rated albums out of ${countData.albums.length} total`);
+                        } else {
+                            ratedAlbumsCount = 0;
+                        }
+                    } else {
+                        // Fallback to current page count
+                        ratedAlbumsCount = data.albums ? data.albums.filter(a => a.is_rated).length : 0;
+                    }
+                } else {
+                    // All albums are in current response
+                    ratedAlbumsCount = data.albums ? data.albums.filter(a => a.is_rated).length : 0;
+                    console.log(`Year ${year}: All albums in first page - ${ratedAlbumsCount} rated`);
+                }
+                
+                // Show/hide collage button based on rated albums
+                const collageBtn = document.getElementById('generate-collage-btn');
+                if (ratedAlbumsCount > 0) {
+                    collageBtn.classList.remove('hidden');
+                }
+            }
+            
+            if (data.albums && data.albums.length === 0 && offset === 0) {
+                document.getElementById('empty-state').classList.remove('hidden');
+                document.getElementById('albums-container').innerHTML = '';
+                document.getElementById('pagination-container').innerHTML = '';
+            } else {
+                document.getElementById('empty-state').classList.add('hidden');
+                
+                if (offset === 0) {
+                    renderAlbums(data);
+                } else {
+                    appendAlbumsToGrid(data);
+                }
+                updatePaginationButton(data);
+            }
+        } else {
+            console.error('Failed to load albums:', response.status);
+            alert('Failed to load albums');
+        }
+    } catch (error) {
+        console.error('Error loading albums:', error);
+        alert('Error loading albums');
+    }
+}
+
+// Collage modal functions
+function openCollageModal() {
+    // Always remove and recreate the modal to ensure the count is up to date
+    const existingModal = document.getElementById('collage-modal');
+    if (existingModal) {
+        existingModal.remove();
+    }
+    createCollageModal();
+    document.getElementById('collage-modal').classList.remove('hidden');
+}
+
+function closeCollageModal() {
+    document.getElementById('collage-modal').classList.add('hidden');
+}
+
+function createCollageModal() {
+    // Use template literal with actual count
+    const allAlbumsOption = ratedAlbumsCount > 0 ? 
+        `<option value="">All Rated Albums (${ratedAlbumsCount})</option>` : 
+        `<option value="">All Rated Albums</option>`;
+    
+    const modalHTML = `
+        <div id="collage-modal" class="hidden fixed inset-0 z-50 overflow-y-auto">
+            <div class="flex items-center justify-center min-h-screen px-4">
+                <!-- Backdrop -->
+                <div class="fixed inset-0 bg-black opacity-50" onclick="closeCollageModal()"></div>
+                
+                <!-- Modal Content -->
+                <div class="relative bg-surface rounded-lg shadow-xl max-w-2xl w-full p-6">
+                    <h2 class="text-2xl font-bold text-primary mb-4">Generate Year End Collage</h2>
+                    
+                    <div class="space-y-4">
+                        <!-- Options -->
+                        <div>
+                            <label class="block text-sm font-medium text-primary mb-2">Maximum Albums</label>
+                            <select id="collage-max-albums" class="w-full px-3 py-2 bg-surface text-primary border border-default rounded-md shadow-sm focus:border-accent-blue focus:ring-accent-blue">
+                                ${allAlbumsOption}
+                                <option value="9">Top 9 (3x3 grid)</option>
+                                <option value="16">Top 16 (4x4 grid)</option>
+                                <option value="25">Top 25 (5x5 grid)</option>
+                                <option value="36">Top 36 (6x6 grid)</option>
+                                <option value="49">Top 49 (7x7 grid)</option>
+                                <option value="64">Top 64 (8x8 grid)</option>
+                                <option value="100">Top 100 (10x10 grid)</option>
+                            </select>
+                        </div>
+                        
+                        <div class="flex items-center space-x-4">
+                            <label class="flex items-center">
+                                <input type="checkbox" id="collage-include-ranking" checked class="mr-2 rounded border-default bg-surface text-accent-blue focus:ring-accent-blue focus:ring-offset-0">
+                                <span class="text-sm text-primary">Include ranking list</span>
+                            </label>
+                            
+                            <label class="flex items-center">
+                                <input type="checkbox" id="collage-include-scores" checked class="mr-2 rounded border-default bg-surface text-accent-blue focus:ring-accent-blue focus:ring-offset-0">
+                                <span class="text-sm text-primary">Show scores</span>
+                            </label>
+                        </div>
+                        
+                        <!-- Preview Container -->
+                        <div id="collage-preview" class="hidden">
+                            <h3 class="text-lg font-medium text-primary mb-2">Preview</h3>
+                            <div class="border border-default rounded-lg p-4 bg-surface-secondary">
+                                <img id="collage-preview-img" src="" alt="Collage preview" class="max-w-full h-auto">
+                            </div>
+                        </div>
+                        
+                        <!-- Loading State -->
+                        <div id="collage-loading" class="hidden text-center py-8">
+                            <div class="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-accent-blue"></div>
+                            <p class="mt-2 text-secondary">Generating collage...</p>
+                        </div>
+                        
+                        <!-- Error State -->
+                        <div id="collage-error" class="hidden bg-error-light border border-error text-error px-4 py-3 rounded">
+                            <p id="collage-error-message"></p>
+                        </div>
+                    </div>
+                    
+                    <!-- Actions -->
+                    <div class="mt-6 flex justify-end space-x-3">
+                        <button onclick="closeCollageModal()" 
+                                class="px-4 py-2 bg-surface-secondary text-primary rounded-md border border-default hover:bg-surface-hover transition-colors">
+                            Cancel
+                        </button>
+                        <button id="generate-btn" onclick="generateCollage()" 
+                                class="bg-accent-blue hover:opacity-90 text-white px-4 py-2 rounded-md text-sm font-medium transition-colors">
+                            Generate Collage
+                        </button>
+                        <a id="download-btn" href="#" download="tracklist_${year}_yearend.png" 
+                           class="hidden bg-success hover:opacity-90 text-white px-4 py-2 rounded-md text-sm font-medium transition-colors">
+                            Download
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    `;
+    
+    document.body.insertAdjacentHTML('beforeend', modalHTML);
+}
+
+async function generateCollage() {
+    const maxAlbums = document.getElementById('collage-max-albums').value;
+    const includeRanking = document.getElementById('collage-include-ranking').checked;
+    const includeScores = document.getElementById('collage-include-scores').checked;
+    
+    // Build URL with parameters
+    let url = `/api/v1/reports/years/${year}/collage?`;
+    url += `include_ranking=${includeRanking}`;
+    url += `&include_scores=${includeScores}`;
+    if (maxAlbums) {
+        url += `&max_albums=${maxAlbums}`;
+    }
+    
+    // Show loading state
+    document.getElementById('collage-loading').classList.remove('hidden');
+    document.getElementById('collage-preview').classList.add('hidden');
+    document.getElementById('collage-error').classList.add('hidden');
+    document.getElementById('generate-btn').disabled = true;
+    document.getElementById('download-btn').classList.add('hidden');
+    
+    try {
+        const response = await fetch(url);
+        
+        if (response.ok) {
+            // Get the image blob
+            const blob = await response.blob();
+            const imageUrl = URL.createObjectURL(blob);
+            
+            // Show preview
+            document.getElementById('collage-preview-img').src = imageUrl;
+            document.getElementById('collage-preview').classList.remove('hidden');
+            
+            // Update download button
+            const downloadBtn = document.getElementById('download-btn');
+            downloadBtn.href = imageUrl;
+            downloadBtn.classList.remove('hidden');
+            
+            // Hide generate button
+            document.getElementById('generate-btn').classList.add('hidden');
+        } else {
+            const error = await response.json();
+            throw new Error(error.message || 'Failed to generate collage');
+        }
+    } catch (error) {
+        console.error('Error generating collage:', error);
+        document.getElementById('collage-error-message').textContent = error.message || 'Failed to generate collage';
+        document.getElementById('collage-error').classList.remove('hidden');
+    } finally {
+        document.getElementById('collage-loading').classList.add('hidden');
+        document.getElementById('generate-btn').disabled = false;
+    }
+}
+
 // Initialize page
 document.addEventListener('DOMContentLoaded', function() {
     document.getElementById('albums-loading').style.display = 'grid';
-    loadYearAlbums();
+    loadYearAlbumsWithButton();  // Use modified function
 });
 </script>
 {% endblock %}


### PR DESCRIPTION
  NEW FEATURES:
  - Add Topsters-style collage generation for year album pages
  - Generate visual grid layouts of album artwork (2x2 to 10x10)
  - Include optional ranked list with album details and scores
  - Support direct download as PNG image
  - Add preview modal with customization options
  - Fallback to direct URL download when artwork not cached

  IMPROVEMENTS:
  - Smart grid calculation for optimal square layouts
  - High-quality image export using original artwork
  - Dark mode compliant UI components
  - Responsive modal with loading states