### PR TITLE
fix: persistent session authentication across server/container restarts

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -6,11 +6,15 @@ from starlette.middleware.base import BaseHTTPMiddleware
 import logging
 import os
 import asyncio
+from dotenv import load_dotenv
 from .database import create_tables, init_db
 from .exceptions import TracklistException
 from .logging_config import setup_logging
 from .routers import search, albums, templates, reports, settings, auth
 from .middleware.auth import auth_middleware
+
+# Load environment variables from .env file
+load_dotenv()
 
 # Setup logging
 log_level = os.getenv("LOG_LEVEL", "INFO")

--- a/app/routers/auth.py
+++ b/app/routers/auth.py
@@ -215,13 +215,17 @@ async def complete_setup(
     
     # Set cookie and redirect
     response = RedirectResponse(url="/", status_code=303)
+    
+    # Use default session expiry for initial setup
+    max_age = auth_service.DEFAULT_EXPIRY_DAYS * 24 * 60 * 60
+    
     response.set_cookie(
         key="tracklist_session",
         value=token,
         httponly=True,  # Not accessible via JavaScript
         secure=request.url.scheme == "https",  # HTTPS only in production
         samesite="strict",  # CSRF protection
-        max_age=30 * 24 * 60 * 60  # 30 days
+        max_age=max_age
     )
     
     return response
@@ -269,8 +273,12 @@ async def login(
     # Set HttpOnly cookie and redirect
     response = RedirectResponse(url=next_url, status_code=303)
     
-    # Determine cookie expiry
-    max_age = 90 * 24 * 60 * 60 if remember_me else 30 * 24 * 60 * 60
+    # Calculate cookie expiry based on actual session configuration
+    # This ensures cookie expiry matches the JWT token expiry
+    expiry_days = auth_service.REMEMBER_ME_DAYS if remember_me else auth_service.DEFAULT_EXPIRY_DAYS
+    max_age = expiry_days * 24 * 60 * 60  # Convert days to seconds
+    
+    logger.debug(f"Setting cookie with max_age={max_age} seconds ({expiry_days} days) for remember_me={remember_me}")
     
     response.set_cookie(
         key="tracklist_session",
@@ -360,8 +368,11 @@ async def login_api(
     if not token:
         raise HTTPException(500, "Failed to create session")
     
-    # Set HttpOnly cookie
-    max_age = 90 * 24 * 60 * 60 if request.remember_me else 30 * 24 * 60 * 60
+    # Calculate cookie expiry based on actual session configuration
+    expiry_days = auth_service.REMEMBER_ME_DAYS if request.remember_me else auth_service.DEFAULT_EXPIRY_DAYS
+    max_age = expiry_days * 24 * 60 * 60  # Convert days to seconds
+    
+    logger.debug(f"API login: Setting cookie with max_age={max_age} seconds ({expiry_days} days) for remember_me={request.remember_me}")
     
     response.set_cookie(
         key="tracklist_session",

--- a/app/services/auth_service.py
+++ b/app/services/auth_service.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm import Session
 from jose import jwt, JWTError
 
 from ..models import UserSettings
+from .session_key_manager import SessionKeyManager
 
 logger = logging.getLogger(__name__)
 
@@ -28,10 +29,23 @@ class AuthService:
     """
     
     # JWT configuration
-    SECRET_KEY = os.getenv("SESSION_SECRET_KEY", os.urandom(32).hex())
+    _SECRET_KEY = None
     ALGORITHM = "HS256"
     DEFAULT_EXPIRY_DAYS = int(os.getenv("SESSION_EXPIRY_DAYS", "30"))
     REMEMBER_ME_DAYS = int(os.getenv("REMEMBER_ME_DAYS", "90"))
+    
+    @classmethod
+    def get_secret_key(cls):
+        """Get or generate the secret key for JWT signing."""
+        if cls._SECRET_KEY is None:
+            # Use SessionKeyManager for automatic persistence
+            cls._SECRET_KEY = SessionKeyManager.get_or_create_key()
+        return cls._SECRET_KEY
+    
+    @property
+    def SECRET_KEY(self):
+        """Property to get secret key."""
+        return self.get_secret_key()
     
     @classmethod
     def is_auth_enabled(cls, db: Session) -> bool:
@@ -197,10 +211,14 @@ class AuthService:
         try:
             settings = db.query(UserSettings).filter(UserSettings.user_id == 1).first()
             if not settings:
+                logger.error("No user settings found when creating session")
                 return None
             
             # Determine expiry
             expiry_days = cls.REMEMBER_ME_DAYS if remember_me else cls.DEFAULT_EXPIRY_DAYS
+            logger.info(f"Creating session with remember_me={remember_me}, expiry_days={expiry_days}")
+            logger.debug(f"REMEMBER_ME_DAYS={cls.REMEMBER_ME_DAYS}, DEFAULT_EXPIRY_DAYS={cls.DEFAULT_EXPIRY_DAYS}")
+            
             expiry = datetime.now(timezone.utc) + timedelta(days=expiry_days)
             
             # Create JWT token
@@ -211,13 +229,21 @@ class AuthService:
                 "remember_me": remember_me
             }
             
-            token = jwt.encode(payload, cls.SECRET_KEY, algorithm=cls.ALGORITHM)
+            logger.debug(f"JWT payload: exp={expiry}, remember_me={remember_me}")
             
-            # Store token and expiry in database (ensure timezone-aware)
+            token = jwt.encode(payload, cls.get_secret_key(), algorithm=cls.ALGORITHM)
+            
+            # Store token and expiry in database
+            # SQLite stores datetimes as text, so we ensure UTC but store without timezone info
+            # to avoid SQLite compatibility issues
             settings.session_token = token
-            settings.session_expiry = expiry.replace(tzinfo=timezone.utc) if expiry.tzinfo is None else expiry
-            settings.last_login = datetime.now(timezone.utc)
+            # Store as naive datetime (SQLite doesn't handle timezones well)
+            # But we know it's always UTC
+            settings.session_expiry = expiry.replace(tzinfo=None) if expiry.tzinfo else expiry
+            settings.last_login = datetime.now(timezone.utc).replace(tzinfo=None)
             db.commit()
+            
+            logger.info(f"Session created successfully - Token: {token[:20]}..., Expiry: {settings.session_expiry}")
             
             return token
             
@@ -232,16 +258,68 @@ class AuthService:
         Checks both JWT validity and database session.
         """
         if not token:
+            logger.debug("No token provided for validation")
             return False
             
         try:
-            # Decode JWT
-            payload = jwt.decode(token, cls.SECRET_KEY, algorithms=[cls.ALGORITHM])
-            
-            # Check database session
+            # First check if token exists in database before attempting JWT decode
+            # This avoids JWT expiry exceptions for known invalid tokens
             settings = db.query(UserSettings).filter(UserSettings.user_id == 1).first()
-            if not settings or settings.session_token != token:
+            if not settings:
+                logger.debug("No user settings found in database")
                 return False
+            
+            if settings.session_token != token:
+                logger.debug("Token mismatch - database token differs from provided token")
+                logger.debug(f"DB token: {settings.session_token[:20] if settings.session_token else 'None'}...")
+                return False
+            
+            # Try to decode JWT - this will raise an exception if expired
+            logger.debug(f"Attempting to decode JWT token: {token[:20]}...")
+            
+            try:
+                # First try normal decode (will fail if expired)
+                # Add leeway to handle small clock skew issues (5 minutes)
+                payload = jwt.decode(token, cls.get_secret_key(), algorithms=[cls.ALGORITHM], 
+                                   options={"leeway": 300})  # 5 minutes leeway for clock skew
+            except jwt.ExpiredSignatureError:
+                # Token is expired according to JWT - but let's check if we should extend it
+                logger.warning("JWT token expired according to signature")
+                
+                # Decode without verification to inspect the payload
+                payload = jwt.decode(token, cls.get_secret_key(), algorithms=[cls.ALGORITHM], 
+                                    options={"verify_exp": False})
+                
+                jwt_exp = payload.get('exp')
+                remember_me = payload.get('remember_me', False)
+                
+                if jwt_exp:
+                    jwt_exp_dt = datetime.fromtimestamp(jwt_exp, tz=timezone.utc)
+                    logger.debug(f"Expired JWT expiry: {jwt_exp_dt}")
+                    logger.debug(f"Remember me flag: {remember_me}")
+                
+                # Check database expiry as fallback
+                if settings.session_expiry:
+                    db_expiry = settings.session_expiry
+                    if db_expiry.tzinfo is None:
+                        db_expiry = db_expiry.replace(tzinfo=timezone.utc)
+                    
+                    if db_expiry > datetime.now(timezone.utc):
+                        logger.warning("JWT expired but database session still valid - possible clock/timezone issue")
+                        # Database says session is still valid, but JWT is expired
+                        # This suggests a timezone or clock sync issue
+                        # For safety, we'll still reject the session
+                
+                return False
+            
+            # Log JWT payload details
+            jwt_exp = payload.get('exp')
+            if jwt_exp:
+                jwt_exp_dt = datetime.fromtimestamp(jwt_exp, tz=timezone.utc)
+                logger.debug(f"JWT expiry from token: {jwt_exp_dt}")
+                logger.debug(f"Current UTC time: {datetime.now(timezone.utc)}")
+                logger.debug(f"JWT is_expired: {jwt_exp_dt < datetime.now(timezone.utc)}")
+                logger.debug(f"Remember me flag in JWT: {payload.get('remember_me', False)}")
             
             # Check expiry
             if settings.session_expiry:
@@ -249,14 +327,25 @@ class AuthService:
                 expiry = settings.session_expiry
                 if expiry.tzinfo is None:
                     # Make expiry timezone-aware if it isn't already
+                    logger.debug(f"Converting naive datetime to UTC: {expiry}")
                     expiry = expiry.replace(tzinfo=timezone.utc)
+                
+                logger.debug(f"DB session expiry: {expiry}")
+                logger.debug(f"Current UTC time: {datetime.now(timezone.utc)}")
+                logger.debug(f"DB session is_expired: {expiry < datetime.now(timezone.utc)}")
+                
                 if expiry < datetime.now(timezone.utc):
+                    logger.info(f"Session expired - DB expiry {expiry} < current time {datetime.now(timezone.utc)}")
                     return False
+            else:
+                logger.debug("No session expiry set in database")
             
+            logger.debug("Session validation successful")
             return True
             
         except JWTError as e:
-            logger.debug(f"JWT validation error: {e}")
+            logger.warning(f"JWT validation error: {e}")
+            logger.debug(f"Token that failed: {token[:20]}...")
             return False
         except Exception as e:
             logger.error(f"Session validation error: {e}")

--- a/app/services/session_key_manager.py
+++ b/app/services/session_key_manager.py
@@ -1,0 +1,109 @@
+"""
+Session key management for persistent JWT signing across restarts.
+Ensures sessions survive application/container restarts.
+"""
+
+import os
+import secrets
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+class SessionKeyManager:
+    """Manages the SESSION_SECRET_KEY with automatic persistence."""
+    
+    KEY_FILE_PATH = "data/.session_key"
+    _instance_key = None
+    
+    @classmethod
+    def get_or_create_key(cls) -> str:
+        """
+        Get the session secret key with the following priority:
+        1. From environment variable SESSION_SECRET_KEY
+        2. From persistent file (for Docker/production)
+        3. Generate new and save to file
+        
+        This ensures sessions survive restarts even without explicit configuration.
+        """
+        if cls._instance_key:
+            return cls._instance_key
+        
+        # Priority 1: Environment variable
+        env_key = os.getenv("SESSION_SECRET_KEY")
+        if env_key:
+            logger.info("Using SESSION_SECRET_KEY from environment variable")
+            cls._instance_key = env_key
+            return env_key
+        
+        # Priority 2: Persistent file (create data dir if needed)
+        key_file = Path(cls.KEY_FILE_PATH)
+        key_file.parent.mkdir(parents=True, exist_ok=True)
+        
+        if key_file.exists():
+            try:
+                with open(key_file, 'r') as f:
+                    stored_key = f.read().strip()
+                if stored_key:
+                    logger.info(f"Using persisted SESSION_SECRET_KEY from {cls.KEY_FILE_PATH}")
+                    cls._instance_key = stored_key
+                    return stored_key
+            except Exception as e:
+                logger.error(f"Error reading session key file: {e}")
+        
+        # Priority 3: Generate new key and persist it
+        new_key = secrets.token_hex(32)
+        try:
+            with open(key_file, 'w') as f:
+                f.write(new_key)
+            # Make file readable only by owner
+            os.chmod(key_file, 0o600)
+            logger.warning(f"Generated new SESSION_SECRET_KEY and saved to {cls.KEY_FILE_PATH}")
+            logger.warning("This is normal on first run, but sessions from previous instances will be invalidated.")
+        except Exception as e:
+            logger.error(f"Failed to save session key to file: {e}")
+            logger.warning("Sessions will not survive restarts without SESSION_SECRET_KEY in environment!")
+        
+        cls._instance_key = new_key
+        return new_key
+    
+    @classmethod
+    def rotate_key(cls, backup: bool = True) -> str:
+        """
+        Rotate the session key (invalidates all existing sessions).
+        
+        Args:
+            backup: If True, backs up the old key before rotating
+            
+        Returns:
+            The new session key
+        """
+        key_file = Path(cls.KEY_FILE_PATH)
+        
+        # Backup old key if requested
+        if backup and key_file.exists():
+            backup_file = key_file.with_suffix('.backup')
+            try:
+                with open(key_file, 'r') as f:
+                    old_key = f.read()
+                with open(backup_file, 'w') as f:
+                    f.write(old_key)
+                os.chmod(backup_file, 0o600)
+                logger.info(f"Backed up old key to {backup_file}")
+            except Exception as e:
+                logger.error(f"Failed to backup old key: {e}")
+        
+        # Generate and save new key
+        new_key = secrets.token_hex(32)
+        try:
+            with open(key_file, 'w') as f:
+                f.write(new_key)
+            os.chmod(key_file, 0o600)
+            logger.warning("SESSION_SECRET_KEY rotated - all existing sessions are now invalid")
+        except Exception as e:
+            logger.error(f"Failed to save new session key: {e}")
+            raise
+        
+        cls._instance_key = new_key
+        return new_key

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,11 @@ services:
       - INTEGRITY_QUICK_CHECK=true
       # Album rating configuration
       - DEFAULT_ALBUM_BONUS=0.33
+      # Authentication configuration
+      # IMPORTANT: Generate a secure key with: openssl rand -hex 32
+      # - SESSION_SECRET_KEY=your-secret-key-here
+      - SESSION_EXPIRY_DAYS=30
+      - REMEMBER_ME_DAYS=90
     volumes:
       - ./data:/app/data
       - ./logs:/app/logs

--- a/scripts/fix_session_expiry.py
+++ b/scripts/fix_session_expiry.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""
+Fix session expiry issues by recalculating expiry times.
+This script can be run to fix existing sessions that may have incorrect expiry times.
+"""
+
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+# Add parent directory to path to import app modules
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from app.models import UserSettings
+from app.services.auth_service import get_auth_service
+from jose import jwt
+
+def fix_session_expiry():
+    """Fix existing session expiry times"""
+    
+    # Connect to database
+    db_path = os.getenv('DATABASE_URL', 'sqlite:///./data/tracklist.db')
+    engine = create_engine(db_path)
+    SessionLocal = sessionmaker(bind=engine)
+    db = SessionLocal()
+    
+    auth_service = get_auth_service()
+    
+    try:
+        # Get current settings
+        settings = db.query(UserSettings).filter(UserSettings.user_id == 1).first()
+        if not settings:
+            print("No user settings found")
+            return
+        
+        if not settings.session_token:
+            print("No active session found")
+            return
+        
+        print(f"Current session token: {settings.session_token[:20]}...")
+        print(f"Current session expiry: {settings.session_expiry}")
+        
+        # Try to decode the JWT token to check its expiry
+        try:
+            # Decode without verification to inspect payload
+            payload = jwt.decode(
+                settings.session_token,
+                auth_service.get_secret_key(),
+                algorithms=[auth_service.ALGORITHM],
+                options={"verify_exp": False, "verify_signature": False}
+            )
+            
+            jwt_exp = payload.get('exp')
+            remember_me = payload.get('remember_me', False)
+            iat = payload.get('iat')
+            
+            if jwt_exp:
+                jwt_exp_dt = datetime.fromtimestamp(jwt_exp, tz=timezone.utc)
+                print(f"\nJWT Token Info:")
+                print(f"  - Expiry: {jwt_exp_dt}")
+                print(f"  - Remember Me: {remember_me}")
+                
+                if iat:
+                    iat_dt = datetime.fromtimestamp(iat, tz=timezone.utc)
+                    print(f"  - Issued At: {iat_dt}")
+                    
+                    # Calculate how long the session was meant to last
+                    duration = jwt_exp_dt - iat_dt
+                    days = duration.days
+                    print(f"  - Duration: {days} days")
+                    
+                    # Check if it matches expected values
+                    expected_days = auth_service.REMEMBER_ME_DAYS if remember_me else auth_service.DEFAULT_EXPIRY_DAYS
+                    print(f"  - Expected: {expected_days} days (remember_me={remember_me})")
+                    
+                    if days != expected_days:
+                        print(f"\n⚠️  MISMATCH: Token duration is {days} days but should be {expected_days} days")
+                
+                # Check if database expiry matches JWT expiry
+                if settings.session_expiry:
+                    db_expiry = settings.session_expiry
+                    # Assume it's UTC even if naive
+                    if db_expiry.tzinfo is None:
+                        db_expiry = db_expiry.replace(tzinfo=timezone.utc)
+                    
+                    print(f"\nDatabase session expiry: {db_expiry}")
+                    
+                    # Compare with JWT expiry
+                    diff = abs((jwt_exp_dt - db_expiry).total_seconds())
+                    if diff > 60:  # More than 1 minute difference
+                        print(f"⚠️  MISMATCH: Database and JWT expiry differ by {diff:.0f} seconds")
+                        
+                        # Fix by updating database to match JWT
+                        print("\nFixing database expiry to match JWT...")
+                        settings.session_expiry = jwt_exp_dt.replace(tzinfo=None)  # Store as naive for SQLite
+                        db.commit()
+                        print("✅ Database expiry updated")
+                    else:
+                        print("✅ Database and JWT expiry match")
+                
+                # Check if session is expired
+                now = datetime.now(timezone.utc)
+                if jwt_exp_dt < now:
+                    print(f"\n❌ Session is EXPIRED (expired {(now - jwt_exp_dt).total_seconds() / 3600:.1f} hours ago)")
+                else:
+                    remaining = jwt_exp_dt - now
+                    print(f"\n✅ Session is VALID (expires in {remaining.days} days, {remaining.seconds // 3600} hours)")
+                    
+        except Exception as e:
+            print(f"Error decoding JWT: {e}")
+        
+    finally:
+        db.close()
+
+if __name__ == "__main__":
+    fix_session_expiry()

--- a/scripts/test_remember_me_fix.py
+++ b/scripts/test_remember_me_fix.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""
+Test the remember me functionality to ensure it properly sets 90-day expiry.
+"""
+
+import os
+import sys
+import requests
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Add parent directory to path
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from app.models import UserSettings
+from app.services.auth_service import get_auth_service
+
+BASE_URL = "http://localhost:8000"
+
+class Colors:
+    OKGREEN = '\033[92m'
+    FAIL = '\033[91m'
+    WARNING = '\033[93m'
+    ENDC = '\033[0m'
+    BOLD = '\033[1m'
+
+def print_test(message):
+    print(f"\n{Colors.BOLD}Testing: {message}{Colors.ENDC}")
+
+def print_pass(message):
+    print(f"{Colors.OKGREEN}✓ {message}{Colors.ENDC}")
+
+def print_fail(message):
+    print(f"{Colors.FAIL}✗ {message}{Colors.ENDC}")
+
+def print_info(message):
+    print(f"{Colors.WARNING}ℹ {message}{Colors.ENDC}")
+
+def test_remember_me():
+    """Test remember me functionality"""
+    
+    print(f"\n{Colors.BOLD}REMEMBER ME FUNCTIONALITY TEST{Colors.ENDC}")
+    print("=" * 50)
+    
+    # Connect to database
+    db_path = os.getenv('DATABASE_URL', 'sqlite:///./data/tracklist.db')
+    engine = create_engine(db_path)
+    SessionLocal = sessionmaker(bind=engine)
+    db = SessionLocal()
+    
+    auth_service = get_auth_service()
+    
+    try:
+        # Check if auth is enabled
+        settings = db.query(UserSettings).filter(UserSettings.user_id == 1).first()
+        if not settings or not settings.auth_enabled:
+            print_fail("Authentication is not enabled. Please enable it first.")
+            return
+        
+        if not settings.password_hash:
+            print_fail("No password set. Please complete setup first.")
+            return
+        
+        session = requests.Session()
+        
+        # Test 1: Login WITHOUT remember_me
+        print_test("Login WITHOUT remember_me (should be 30 days)")
+        
+        # Clear any existing session
+        settings.session_token = None
+        settings.session_expiry = None
+        db.commit()
+        
+        # Note: We can't actually test the login without knowing the password
+        # So we'll simulate by creating a session directly
+        token = auth_service.create_session(db, remember_me=False)
+        if token:
+            # Check the expiry in database
+            db.refresh(settings)
+            if settings.session_expiry:
+                expiry = settings.session_expiry
+                if expiry.tzinfo is None:
+                    expiry = expiry.replace(tzinfo=timezone.utc)
+                
+                now = datetime.now(timezone.utc)
+                days_diff = (expiry - now).days
+                
+                print_info(f"Session expires: {expiry}")
+                print_info(f"Days until expiry: {days_diff}")
+                
+                if 29 <= days_diff <= 31:  # Allow some tolerance
+                    print_pass(f"Default session is ~30 days ({days_diff} days)")
+                else:
+                    print_fail(f"Expected ~30 days, got {days_diff} days")
+        
+        # Test 2: Login WITH remember_me
+        print_test("Login WITH remember_me (should be 90 days)")
+        
+        # Clear session again
+        settings.session_token = None
+        settings.session_expiry = None
+        db.commit()
+        
+        # Create session with remember_me
+        token = auth_service.create_session(db, remember_me=True)
+        if token:
+            # Check the expiry in database
+            db.refresh(settings)
+            if settings.session_expiry:
+                expiry = settings.session_expiry
+                if expiry.tzinfo is None:
+                    expiry = expiry.replace(tzinfo=timezone.utc)
+                
+                now = datetime.now(timezone.utc)
+                days_diff = (expiry - now).days
+                
+                print_info(f"Session expires: {expiry}")
+                print_info(f"Days until expiry: {days_diff}")
+                
+                if 89 <= days_diff <= 91:  # Allow some tolerance
+                    print_pass(f"Remember me session is ~90 days ({days_diff} days)")
+                else:
+                    print_fail(f"Expected ~90 days, got {days_diff} days")
+        
+        # Test 3: Check environment variables
+        print_test("Environment variable configuration")
+        
+        print_info(f"DEFAULT_EXPIRY_DAYS: {auth_service.DEFAULT_EXPIRY_DAYS}")
+        print_info(f"REMEMBER_ME_DAYS: {auth_service.REMEMBER_ME_DAYS}")
+        
+        if auth_service.REMEMBER_ME_DAYS == 90:
+            print_pass("REMEMBER_ME_DAYS is correctly set to 90")
+        else:
+            print_fail(f"REMEMBER_ME_DAYS is {auth_service.REMEMBER_ME_DAYS}, expected 90")
+        
+        if auth_service.DEFAULT_EXPIRY_DAYS == 30:
+            print_pass("DEFAULT_EXPIRY_DAYS is correctly set to 30")
+        else:
+            print_fail(f"DEFAULT_EXPIRY_DAYS is {auth_service.DEFAULT_EXPIRY_DAYS}, expected 30")
+        
+    finally:
+        db.close()
+    
+    print(f"\n{Colors.BOLD}TEST COMPLETE{Colors.ENDC}")
+    print("=" * 50)
+    print("\nTo fully test the remember me functionality:")
+    print("1. Log out if currently logged in")
+    print("2. Log in WITHOUT checking 'Remember me'")
+    print("3. Run scripts/fix_session_expiry.py to check expiry (should be ~30 days)")
+    print("4. Log out and log in again WITH 'Remember me' checked")
+    print("5. Run scripts/fix_session_expiry.py to check expiry (should be ~90 days)")
+
+if __name__ == "__main__":
+    test_remember_me()


### PR DESCRIPTION
This fixes the critical bug where users were being logged out after server restarts despite selecting "Remember me for 90 days". The root cause was the SESSION_SECRET_KEY being randomly generated on each startup.

Changes:
- Add automatic session key persistence via SessionKeyManager
- Store persistent key in data/.session_key (survives Docker restarts)
- Add dotenv loading to main.py for .env file support
- Fix cookie max_age to match actual JWT token expiry
- Add 5-minute clock skew tolerance to JWT validation
- Add comprehensive debug logging for session validation
- Include diagnostic scripts for troubleshooting sessions

The fix implements a three-tier priority system:
1. SESSION_SECRET_KEY environment variable (if set)
2. Persistent file in data/.session_key (auto-created)
3. Generated key (last resort, with warning)

This ensures Docker Compose users get persistent sessions without any configuration, while production deployments can explicitly set the key.